### PR TITLE
Change fast-setup.sh to use shallow-since

### DIFF
--- a/docs/source/Getting-Started/Install-Dependencies.rst
+++ b/docs/source/Getting-Started/Install-Dependencies.rst
@@ -14,4 +14,9 @@ Ubuntu
   gperf libgmp-dev libmpc-dev libmpfr-dev libtool texinfo tmux \
   patchutils zlib1g-dev wget bzip2 patch vim-common lbzip2 python \
   pkg-config libglib2.0-dev libpixman-1-dev libssl-dev screen \
-  device-tree-compiler expect makeself unzip cpio rsync cmake
+  device-tree-compiler expect makeself unzip cpio rsync cmakev
+
+.. note::
+  You need Git version >= 2.11.0 to use ``./fast-setup.sh``, because the script uses
+  ``--shallow-clone`` for faster submodule initializtion.
+

--- a/docs/source/Getting-Started/QEMU-Setup-Repository.rst
+++ b/docs/source/Getting-Started/QEMU-Setup-Repository.rst
@@ -11,7 +11,7 @@ You can either quickly setup everything (:ref:`QEMUSetupQuick`) or manually setu
 Quick Setup
 ########################
 
-You can quickly setup everything by running ``./fast-setup.sh``
+You can quickly setup everything by running ``./fast-setup.sh``. This script requires Git >= 2.11.0.
 
 ::
 

--- a/fast-setup.sh
+++ b/fast-setup.sh
@@ -41,9 +41,17 @@ fi
 
 echo "Updating and cloning submodules, this may take a long time"
 git config submodule.riscv-gnu-toolchain.update none
-git config -f .gitmodules submodule.linux.shallow true
-git config -f .gitmodules submodule.qemu.shallow true
-git config -f .gitmodules submodule.buildroot.shallow true
+
+# shallow clone submodules ahead of time (Git must be > 2.11)
+if [ ! -d linux ]; then
+  git clone --shallow-since=2019-09-14 https://github.com/torvalds/linux.git linux
+fi
+if [ ! -d buildroot ]; then
+  git clone --shallow-since=2019-08-29 https://github.com/buildroot/buildroot.git buildroot
+fi
+if [ ! -d qemu ]; then
+  git clone --shallow-since=2018-08-14 https://github.com/qemu/qemu.git qemu
+fi
 
 git submodule sync --recursive
 git submodule update --init --recursive


### PR DESCRIPTION
Shallow cloning will not work since we are now referring to active
upstream URL.
Use git clone with --shallow-since to make it work and also reduce the
time for cloning submodules. This works for Git >= 2.11