### PR TITLE
Add -device virtio-rng-pci to qemu options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,8 @@ add_custom_command(OUTPUT ${scripts}/run-qemu.sh DEPENDS ${scripts}
       -kernel ${sm_wrkdir}/bbl \
       ${extra_qemu_options} \
       -netdev user,id=net0,net=192.168.100.1/24,dhcpstart=192.168.100.128,hostfwd=tcp::\$\{HOST_PORT\}-:22 \
-      -device virtio-net-device,netdev=net0" > run-qemu.sh
+      -device virtio-net-device,netdev=net0 \
+      -device virtio-rng-pci" > run-qemu.sh
       VERBATIM
     COMMAND
       chmod +x run-qemu.sh


### PR DESCRIPTION
(Sorry for the previous PR against wrong branch.)

There are warnings for random device on dmesg when runing on qemu.
```
[    0.741849] random: dd: uninitialized urandom read (512 bytes read)
[    1.119964] random: dropbear: uninitialized urandom read (32 bytes read)
```
Also getrandom() call blocks in the tiny test:
```
#include <sys/random.h>

int main() { char buf[8]; return getrandom(buf, 8, 0); }
```
With adding "-device virtio-rng-pci" to the qemu command line, the above test returns 8 and there are no warnings for random from kernel.