### PR TITLE
Corrected data block limit for attestation to 1k from 2k in docs. Now…

### DIFF
--- a/docs/source/Keystone-Applications/Attestation.rst
+++ b/docs/source/Keystone-Applications/Attestation.rst
@@ -46,7 +46,7 @@ All signed by the device root key.
 
 Enclave report contains:
  - A hash of the enclave at initialization
- - A data block from the enclave of up-to 2KB in size
+ - A data block from the enclave of up-to 1KB in size
 
 All signed by the attestation public key.
 


### PR DESCRIPTION
… matches implementation.
As pointed out by kenun99 <cwmjy1314@gmail.com> on the mailing list.