### PR TITLE
test-runner: Output EAPP errors and check against them in log

### DIFF
--- a/tests/tests/Makefile
+++ b/tests/tests/Makefile
@@ -29,6 +29,7 @@ all:  $(OBJS) $(SDK_HOST_LIB) $(SDK_EDGE_LIB) $(SDK_VERIFIER_LIB)
 	$(foreach test, $(TESTS), \
 		echo "echo 'testing $(test)'" >> test;\
 		echo "./$(RUNNER) $(test).eapp_riscv $(RUNTIME)" >> test; \
+		echo '[ $$? -eq 0 ] || echo "... ERROR"' >> test; \
 	)
 	chmod +x test
 

--- a/tests/tests/test-runner.cpp
+++ b/tests/tests/test-runner.cpp
@@ -133,8 +133,9 @@ int main(int argc, char** argv)
     asm volatile ("rdcycle %0" : "=r" (cycles3));
   }
 
+  int retcode = 0;
   if( !load_only )
-    enclave.run();
+    retcode = enclave.run();
 
   if( self_timing ){
     asm volatile ("rdcycle %0" : "=r" (cycles4));
@@ -142,5 +143,5 @@ int main(int argc, char** argv)
     printf("[keystone-test] Runtime: %lu cycles\r\n", cycles4-cycles3);
   }
 
-  return 0;
+  return retcode;
 }


### PR DESCRIPTION
Previously, if an EAPP would fail in the middle of execution the test runner would proceed as if nothing happened (assuming the test didn't hang forever). This allows us to catch these kinds of issues without manually inspecting the QEMU log.