### PR TITLE
Allow out-of-tree builds for tests, clean up CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,20 +203,22 @@ elseif(sifive)
   add_patch("riscv-pk" "riscv-pk.sifive.patch" ${sm_srcdir} "sm")
 endif()
 
-add_dependencies("sm" "linux")
 add_dependencies("driver" "linux")
 
 add_custom_command(OUTPUT ${tests_wrkdir} COMMAND mkdir -p ${tests_wrkdir})
-add_custom_target("tests" DEPENDS "driver" ${overlay_root} ${tests_srcdir} ${tests_wrkdir}
+add_custom_target("tests" DEPENDS ${tests_srcdir} ${tests_wrkdir}
   COMMAND OUTPUT_DIR=${overlay_root} ARTIFACTS_DIR=${tests_wrkdir} ${tests_srcdir}/tests/vault.sh
-  COMMAND find ${driver_wrkdir} -name "*.ko" -exec cp {} ${overlay_root} \\\\;
   COMMENT "Building tests"
 )
 
-add_custom_target("image" DEPENDS "sm" "tests" "buildroot"
+add_custom_target("image-deps" DEPENDS "sm" "tests" "driver"
+  COMMAND find ${driver_wrkdir} -name "*.ko" -exec cp {} ${overlay_root} \\\\;
+)
+add_custom_target("image" DEPENDS "buildroot"
   COMMAND ${cross_compile}objcopy -S -O binary --change-addresses -0x80000000 ${sm_wrkdir}/bbl ${final_image}
   COMMENT "Generating image"
 )
+add_dependencies("buildroot" "image-deps")
 
 # scripts
 set(scripts ${CMAKE_BINARY_DIR}/scripts)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,17 @@ if(NOT DEFINED ENV{RISCV})
 	message(FATAL_ERROR "set RISCV environment variable. \n Try `cd ${CMAKE_SOURCE_DIR}; source source.sh`")
 endif()
 
-if(NOT DEFINED platform)
-  set(platform "default")
-endif()
+set(SM_PLATFORM "default" CACHE STRING "Board name for SM hardware-specific functions")
+set(platform ${SM_PLATFORM})
 message(STATUS "platform=${platform}")
 
+set (Debug (${CMAKE_BUILD_TYPE} == "Debug"))
 if(Debug)
   message(STATUS "debug")
   set(CFLAGS -g)
 endif()
 
+set(RISCV32 OFF CACHE BOOL "Build in 32-bit mode")
 if(RISCV32)
   message(STATUS "riscv32")
   set(BITS 32)
@@ -67,6 +68,7 @@ set(linux_vmlinux_stripped ${linux_wrkdir}/vmlinux-stripped)
 set(driver_srcdir ${CMAKE_SOURCE_DIR}/linux-keystone-driver)
 set(driver_wrkdir ${CMAKE_BINARY_DIR}/linux-keystone-driver.build)
 set(tests_srcdir ${CMAKE_SOURCE_DIR}/tests)
+set(tests_wrkdir ${CMAKE_BINARY_DIR}/tests.build)
 set(final_image ${CMAKE_BINARY_DIR}/bbl.bin)
 set(initramfs_sysroot ${CMAKE_BINARY_DIR}/initramfs-sysroot)
 
@@ -200,14 +202,14 @@ endif()
 add_dependencies("sm" "linux")
 add_dependencies("driver" "linux")
 
-add_custom_target("tests" DEPENDS "driver" ${overlay_root} ${tests_srcdir}
-  COMMAND OUTPUT_DIR=${overlay_root} ${tests_srcdir}/tests/vault.sh
+add_custom_command(OUTPUT ${tests_wrkdir} COMMAND mkdir -p ${tests_wrkdir})
+add_custom_target("tests" DEPENDS "driver" ${overlay_root} ${tests_srcdir} ${tests_wrkdir}
+  COMMAND OUTPUT_DIR=${overlay_root} ARTIFACTS_DIR=${tests_wrkdir} ${tests_srcdir}/tests/vault.sh
   COMMAND find ${driver_wrkdir} -name "*.ko" -exec cp {} ${overlay_root} \\\\;
   COMMENT "Building tests"
 )
 
-add_custom_target("image" DEPENDS "sm" "tests" ${buildroot_srcdir} ${buildroot_wrkdir}/.config ${overlay_root}
-  COMMAND $(MAKE) -s -C ${buildroot_srcdir} RISCV=$ENV{RISCV} PATH=$ENV{PATH} O=${buildroot_wrkdir}
+add_custom_target("image" DEPENDS "sm" "tests" "buildroot"
   COMMAND ${cross_compile}objcopy -S -O binary --change-addresses -0x80000000 ${sm_wrkdir}/bbl ${final_image}
   COMMENT "Generating image"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,41 @@ project(keystone C)
 include(ProcessorCount)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
+
+###############################################################################
+## MACROS
+###############################################################################
+
+# add patch macro
+macro(add_patch submodule patch working_directory patch_list)
+  add_custom_command(OUTPUT ${patch}.applied
+    WORKING_DIRECTORY ${working_directory}
+    COMMAND patch --forward -p0 < ${patchdir}/${submodule}/${patch} || true
+    COMMAND touch ${CMAKE_BINARY_DIR}/${patch}.applied
+    COMMENT "Applying ${patch}")
+  list(APPEND ${patch_list} ${patch}.applied)
+endmacro()
+
+macro(mkdir name dir)
+  add_custom_command(OUTPUT ${dir}/.exists
+    COMMAND mkdir -p ${dir}
+    COMMAND touch ${dir}/.exists
+  )
+  set(${name} ${dir})
+  set(${name}_exists ${dir}/.exists)
+endmacro()
+
+
+###############################################################################
+## CONFIGURATION/VARIABLES
+###############################################################################
+
 if(NOT DEFINED ENV{RISCV})
 	message(FATAL_ERROR "set RISCV environment variable. \n Try `cd ${CMAKE_SOURCE_DIR}; source source.sh`")
 endif()
 
+set(USE_RUST_SM FALSE CACHE BOOL "Use Rust version of the security monitor.")
+set(SM_CONFIGURE_ARGS --enable-opt=2 CACHE STRING "Security Monitor configure script arguments")
 set(SM_PLATFORM "default" CACHE STRING "Board name for SM hardware-specific functions")
 set(platform ${SM_PLATFORM})
 message(STATUS "platform=${platform}")
@@ -15,9 +46,8 @@ set(LINUX_SIFIVE FALSE CACHE BOOL "Build linux for sifive")
 set(sifive ${LINUX_SIFIVE})
 message(STATUS "sifive=${sifive}")
 
-set (Debug (${CMAKE_BUILD_TYPE} == "Debug"))
-if(Debug)
-  message(STATUS "debug")
+if((CMAKE_BUILD_TYPE MATCHES "Debug") OR (CMAKE_BUILD_TYPE MATCHES "RelWithDebInfo"))
+  message(STATUS "Using debug symbols")
   set(CFLAGS -g)
 endif()
 
@@ -42,7 +72,7 @@ set(bootrom_wrkdir ${CMAKE_BINARY_DIR}/bootrom.build)
 set(qemu_wrkdir ${CMAKE_SOURCE_DIR}/qemu)
 set(qemu_srcdir ${CMAKE_SOURCE_DIR}/qemu)
 set(sm_srcdir ${CMAKE_SOURCE_DIR}/riscv-pk)
-set(sm_wrkdir ${CMAKE_BINARY_DIR}/riscv-pk.build)
+mkdir(sm_wrkdir ${CMAKE_BINARY_DIR}/riscv-pk.build)
 set(buildroot_srcdir ${CMAKE_SOURCE_DIR}/buildroot)
 set(buildroot_wrkdir ${CMAKE_BINARY_DIR}/buildroot.build)
 set(buildroot_config ${confdir}/qemu_riscv${BITS}_virt_defconfig)
@@ -66,7 +96,7 @@ if(NOT DEFINED linux_defconfig)
 endif()
 
 set(linux_srcdir ${CMAKE_SOURCE_DIR}/linux)
-set(linux_wrkdir ${CMAKE_BINARY_DIR}/linux.build)
+mkdir(linux_wrkdir ${CMAKE_BINARY_DIR}/linux.build)
 set(linux_vmlinux ${linux_wrkdir}/vmlinux)
 set(linux_vmlinux_stripped ${linux_wrkdir}/vmlinux-stripped)
 set(driver_srcdir ${CMAKE_SOURCE_DIR}/linux-keystone-driver)
@@ -76,35 +106,32 @@ set(tests_wrkdir ${CMAKE_BINARY_DIR}/tests.build)
 set(final_image ${CMAKE_BINARY_DIR}/bbl.bin)
 set(initramfs_sysroot ${CMAKE_BINARY_DIR}/initramfs-sysroot)
 
-set(USE_RUST_SM FALSE CACHE BOOL "Use Rust version of the security monitor.")
-if (${USE_RUST_SM})
-  set(enabled_sm --enable-sm_rs)
-else()
-  set(enabled_sm --enable-sm)
-endif()
-set(SM_CONFIGURE_ARGS --enable-opt=2 CACHE STRING "Security Monitor configure script arguments")
 
-# add patch macro
-macro(add_patch submodule patch working_directory depend_by)
-  add_custom_target(${patch} WORKING_DIRECTORY ${working_directory}
-    COMMAND patch --forward -p0 < ${patchdir}/${submodule}/${patch} || true
-    COMMENT "Applying ${patch}")
-  add_dependencies(${depend_by} ${patch})
-endmacro()
+###############################################################################
+## COMPONENT: QEMU
+###############################################################################
 
-# QEMU
 set(qemu_system ${qemu_wrkdir}/riscv${BITS}-softmmu/qemu-system-riscv${BITS})
+add_patch("qemu" "qemu-pmp-bug.patch" ${qemu_srcdir} qemu_patches)
+add_patch("qemu" "qemu-secure-boot.patch" ${qemu_srcdir} qemu_patches)
+
 add_custom_target("qemu" ALL DEPENDS ${qemu_system})
-add_custom_command(OUTPUT ${qemu_system} COMMAND $(MAKE) -C ${qemu_srcdir} DEPENDS ${qemu_wrkdir}/config-host.mak COMMENT "Building QEMU")
+add_custom_command(OUTPUT ${qemu_system}
+  COMMAND $(MAKE) -C ${qemu_srcdir}
+  DEPENDS ${qemu_wrkdir}/config-host.mak ${qemu_patches}
+  COMMENT "Building QEMU"
+)
 add_custom_command(OUTPUT ${qemu_wrkdir}/config-host.mak
   WORKING_DIRECTORY ${qemu_srcdir}
   COMMAND ./configure --target-list=riscv${BITS}-softmmu,riscv${BITS}-linux-user
   COMMENT "Configuring QEMU"
 )
-add_patch("qemu" "qemu-pmp-bug.patch" ${qemu_srcdir} "qemu")
-add_patch("qemu" "qemu-secure-boot.patch" ${qemu_srcdir} "qemu")
 
-# buildroot
+
+###############################################################################
+## COMPONENT: buildroot
+###############################################################################
+
 add_custom_command(OUTPUT ${overlay_root} COMMAND mkdir -p ${overlay_root})
 add_custom_command(OUTPUT ${overlay_dir} COMMAND mkdir -p ${overlay_dir})
 add_custom_command(OUTPUT ${buildroot_wrkdir} COMMAND mkdir -p ${buildroot_wrkdir})
@@ -123,7 +150,11 @@ add_custom_command(DEPENDS ${buildroot_config} OUTPUT ${buildroot_wrkdir}/.confi
   COMMENT "Configuring buildroot (overlay = ${overlay_dir})"
 )
 
-# boot ROM
+
+###############################################################################
+## component: bootrom
+###############################################################################
+
 add_custom_command(OUTPUT ${bootrom_wrkdir} COMMAND mkdir -p ${bootrom_wrkdir})
 add_custom_target("bootrom" ALL
   COMMAND $(MAKE) -C ${bootrom_srcdir} O=${bootrom_wrkdir}
@@ -131,13 +162,24 @@ add_custom_target("bootrom" ALL
   COMMENT "Building bootrom"
 )
 
-# linux
-add_custom_command(OUTPUT ${linux_wrkdir} COMMAND mkdir -p ${linux_wrkdir})
-add_custom_command(OUTPUT ${linux_wrkdir}/.config DEPENDS ${linux_defconfig} ${linux_wrkdir}
+
+###############################################################################
+## COMPONENT: linux kernel 
+###############################################################################
+
+add_custom_command(OUTPUT ${linux_wrkdir}/.config DEPENDS ${linux_defconfig} ${linux_wrkdir_exists}
   COMMAND cp ${linux_defconfig} ${linux_wrkdir}/.config
   COMMAND $(MAKE) -C ${linux_srcdir} O=${linux_wrkdir} ARCH=riscv olddefconfig
   COMMENT "Configuring linux"
 )
+
+if(firesim)
+  add_patch("linux" "linux${BITS}.firesim.patch" ${linux_srcdir} linux_patches)
+elseif(sifive)
+  add_patch("linux" "linux${BITS}.sifive.patch" ${linux_srcdir} linux_patches)
+else()
+  add_patch("linux" "linux${BITS}.patch" ${linux_srcdir} linux_patches)
+endif()
 
 
 if(initramfs)
@@ -151,7 +193,7 @@ if(initramfs)
     COMMAND tar -xpf ${buildroot_wrkdir}/images/rootfs.tar -C ${initramfs_sysroot} --exclude ./dev --exclude ./usr/share/locale
     COMMAND echo "::sysinit:/bin/mount -t devtmpfs devtmpfs /dev" >> ${initramfs_sysroot}/etc/inittab
     )
-  add_custom_target("linux" ALL DEPENDS "sysroot" ${linux_srcdir} ${linux_wrkdir}/.config
+  add_custom_command(OUTPUT ${linux_vmlinux_stripped} ${linux_vmlinux} DEPENDS "sysroot" ${linux_srcdir} ${linux_wrkdir}/.config ${linux_patches}
     COMMAND $(MAKE) -C ${linux_srcdir}
       O=${linux_wrkdir} CONFIG_INITRAMFS_SOURCE="${confdir}/initramfs.txt ${initramfs_sysroot}"
       CONFIG_INITRAMFS_ROOT_UID=${uid} CONFIG_INITRAMFS_ROOT_GID=${gid}
@@ -161,23 +203,19 @@ if(initramfs)
     COMMENT "Building linux (initramfs)"
   )
 else()
-  add_custom_target("linux" ALL DEPENDS ${linux_srcdir} ${linux_wrkdir}/.config
+  add_custom_command(OUTPUT ${linux_vmlinux_stripped} ${linux_vmlinux} DEPENDS ${linux_srcdir} ${linux_wrkdir}/.config ${linux_patches}
     COMMAND $(MAKE) -C ${linux_srcdir} O=${linux_wrkdir} CROSS_COMPILE=${cross_compile} ARCH=riscv vmlinux
     COMMAND ${cross_compile}strip -o ${linux_vmlinux_stripped} ${linux_vmlinux}
     COMMENT "Building linux"
   )
 endif()
 
-if(firesim)
-  add_patch("linux" "linux${BITS}.firesim.patch" ${linux_srcdir} "linux")
-elseif(sifive)
-  add_patch("linux" "linux${BITS}.sifive.patch" ${linux_srcdir} "linux")
-else()
-  add_patch("linux" "linux${BITS}.patch" ${linux_srcdir} "linux")
-endif()
+add_custom_target("linux" ALL DEPENDS ${linux_vmlinux_stripped} ${linux_vmlinux})
 
+###############################################################################
+## COMPONENT: linux driver
+###############################################################################
 
-# linux module
 add_custom_command(OUTPUT ${driver_wrkdir} COMMAND mkdir -p ${driver_wrkdir})
 add_custom_target("driver-sync" DEPENDS ${driver_srcdir} ${driver_wrkdir}
 	COMMAND rsync -r ${driver_srcdir}/ ${driver_wrkdir})
@@ -187,12 +225,24 @@ add_custom_target("driver" ALL DEPENDS ${driver_srcdir} ${linux_srcdir} "linux" 
   COMMENT "Building driver"
 )
 
-# bbl + sm
-add_custom_command(OUTPUT ${sm_wrkdir} COMMAND mkdir -p ${sm_wrkdir})
-add_custom_target("sm" ALL DEPENDS ${sm_srcdir} ${sm_wrkdir} ${linux_vmlinux_stripped} WORKING_DIRECTORY ${sm_wrkdir}
+
+###############################################################################
+## COMPONENT: bbl + sm
+###############################################################################
+
+if (${USE_RUST_SM})
+  set(enabled_sm --enable-sm_rs)
+else()
+  set(enabled_sm --enable-sm)
+endif()
+
+add_custom_command(OUTPUT ${sm_wrkdir}/Makefile WORKING_DIRECTORY ${sm_wrkdir}
+  DEPENDS ${sm_wrkdir_exists} "linux"
   COMMAND ${sm_srcdir}/configure --host=riscv${BITS}-unknown-linux-gnu --with-payload=${linux_vmlinux_stripped}
-    --enable-logo --with-logo=${confdir}/sifive_logo.txt --with-target-platform=${platform}
     --enable-logo --with-logo=${confdir}/sifive_logo.txt ${enabled_sm} ${SM_CONFIGURE_ARGS} --with-target-platform=${platform}
+  COMMENT "Configuring sm"
+)
+add_custom_target("sm" ALL DEPENDS ${sm_wrkdir}/Makefile WORKING_DIRECTORY ${sm_wrkdir}
   COMMAND env CFLAGS='${CFLAGS} -mabi=${ABI} -march=${ISA}' $(MAKE) -C ${sm_wrkdir}
   COMMENT "Building sm"
 )
@@ -203,13 +253,21 @@ elseif(sifive)
   add_patch("riscv-pk" "riscv-pk.sifive.patch" ${sm_srcdir} "sm")
 endif()
 
-add_dependencies("driver" "linux")
+
+###############################################################################
+## COMPONENT: tests
+###############################################################################
 
 add_custom_command(OUTPUT ${tests_wrkdir} COMMAND mkdir -p ${tests_wrkdir})
 add_custom_target("tests" DEPENDS ${tests_srcdir} ${tests_wrkdir}
   COMMAND OUTPUT_DIR=${overlay_root} ARTIFACTS_DIR=${tests_wrkdir} ${tests_srcdir}/tests/vault.sh
   COMMENT "Building tests"
 )
+
+
+###############################################################################
+## COMPONENT: image
+###############################################################################
 
 add_custom_target("image-deps" DEPENDS "sm" "tests" "driver"
   COMMAND find ${driver_wrkdir} -name "*.ko" -exec cp {} ${overlay_root} \\\\;
@@ -219,6 +277,11 @@ add_custom_target("image" DEPENDS "buildroot"
   COMMENT "Generating image"
 )
 add_dependencies("buildroot" "image-deps")
+
+
+###############################################################################
+## QEMU scripts
+###############################################################################
 
 # scripts
 set(scripts ${CMAKE_BINARY_DIR}/scripts)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ set(SM_PLATFORM "default" CACHE STRING "Board name for SM hardware-specific func
 set(platform ${SM_PLATFORM})
 message(STATUS "platform=${platform}")
 
+set(LINUX_SIFIVE FALSE CACHE BOOL "Build linux for sifive")
+set(sifive ${LINUX_SIFIVE})
+message(STATUS "sifive=${sifive}")
+
 set (Debug (${CMAKE_BUILD_TYPE} == "Debug"))
 if(Debug)
   message(STATUS "debug")

--- a/docs/source/Getting-Started/QEMU-Compile-Sources.rst
+++ b/docs/source/Getting-Started/QEMU-Compile-Sources.rst
@@ -100,7 +100,7 @@ Optionally, you can specify the target platform when you run ``cmake``.
 ::
 
   # in your <build directory>
-  cmake .. -Dplatform=fu540
+  cmake .. -DSM_PLATFORM=fu540
   make sm
 
 The default platform is "default", which does not have any platform-specific features.

--- a/docs/source/Getting-Started/Running-Keystone-on-Hardware.rst
+++ b/docs/source/Getting-Started/Running-Keystone-on-Hardware.rst
@@ -24,7 +24,7 @@ After you setup the repository, you can run the following commands to build Keys
   
   mkdir <build directory>
   cd <build directory>
-  cmake .. -Dsifive=y
+  cmake .. -DLINUX_SIFIVE=y
   make
   make image
 

--- a/tests/tests/Makefile
+++ b/tests/tests/Makefile
@@ -1,46 +1,60 @@
-CC = riscv64-unknown-linux-gnu-g++
-OBJCOPY = riscv64-unknown-linux-gnu-objcopy
+CC := riscv64-unknown-linux-gnu-g++
+OBJCOPY := riscv64-unknown-linux-gnu-objcopy
 
-SDK_LIB_DIR =$(KEYSTONE_SDK_DIR)/lib
-SDK_HOST_LIB = $(SDK_LIB_DIR)/libkeystone-host.a
-SDK_EDGE_LIB = $(SDK_LIB_DIR)/libkeystone-edge.a
-SDK_VERIFIER_LIB = $(SDK_LIB_DIR)/libkeystone-verifier.a
+SDK_LIB_DIR := $(KEYSTONE_SDK_DIR)/lib
+SDK_HOST_LIB := $(SDK_LIB_DIR)/libkeystone-host.a
+SDK_EDGE_LIB := $(SDK_LIB_DIR)/libkeystone-edge.a
+SDK_VERIFIER_LIB := $(SDK_LIB_DIR)/libkeystone-verifier.a
 
-SDK_INCLUDE_HOST_DIR = $(SDK_LIB_DIR)/host/include
-SDK_INCLUDE_EDGE_DIR = $(SDK_LIB_DIR)/edge/include
-SDK_INCLUDE_VERIFIER_DIR = $(SDK_LIB_DIR)/verifier
+SDK_INCLUDE_HOST_DIR := $(SDK_LIB_DIR)/host/include
+SDK_INCLUDE_EDGE_DIR := $(SDK_LIB_DIR)/edge/include
+SDK_INCLUDE_VERIFIER_DIR := $(SDK_LIB_DIR)/verifier
 
-RUNTIME=eyrie-rt
-RUNNER=test-runner.riscv
-CCFLAGS = -I$(SDK_INCLUDE_HOST_DIR) -I$(SDK_INCLUDE_EDGE_DIR) -I$(SDK_INCLUDE_VERIFIER_DIR) -std=c++11
-LDFLAGS = -L$(SDK_LIB_DIR)
+O := $(shell pwd)
+
+RUNTIME := eyrie-rt
+RUNNER := test-runner.riscv
+CCFLAGS := -I$(SDK_INCLUDE_HOST_DIR) -I$(SDK_INCLUDE_EDGE_DIR) -I$(SDK_INCLUDE_VERIFIER_DIR) -std=c++11
+LDFLAGS := -L$(SDK_LIB_DIR)
 
 TESTS=stack fibonacci long-nop loop malloc fib-bench untrusted attestation
 
-SRCS = $(patsubst %.riscv, %.cpp, $(RUNNER))
-OBJS = $(patsubst %.riscv, %.o,$(RUNNER)) $(KEYSTONE_OBJ) edge_wrapper.o
+OBJS := $(patsubst %.riscv, %.o,$(RUNNER)) $(KEYSTONE_OBJ) edge_wrapper.o
+SRCS := $(patsubst %.o, %.cpp, $(OBJS))
 
-all:  $(OBJS) $(SDK_HOST_LIB) $(SDK_EDGE_LIB) $(SDK_VERIFIER_LIB)
-	$(CC) $(CCFLAGS) $(LDFLAGS) -o $(RUNNER) $^
+DST_OBJS := $(addprefix $(O)/, $(OBJS))
+DST_RUNNER := $(O)/$(RUNNER)
+DST_TEST_SCRIPT := $(O)/test
+
+.PHONY: all clean tests
+
+all: $(DST_RUNNER) tests
+
+tests $(DST_TEST_SCRIPT):
 	$(foreach test, $(TESTS),\
-		$(MAKE) -C $(test);\
+		$(MAKE) -C $(test) O=$(O)/$(test) ;\
 	)
-	rm -f test
+	rm -f $(DST_TEST_SCRIPT)
 	$(foreach test, $(TESTS), \
-		echo "echo 'testing $(test)'" >> test;\
-		echo "./$(RUNNER) $(test).eapp_riscv $(RUNTIME)" >> test; \
-		echo '[ $$? -eq 0 ] || echo "... ERROR"' >> test; \
+		echo "echo 'testing $(test)'"                    >> $(DST_TEST_SCRIPT) ;\
+		echo "./$(RUNNER) $(test).eapp_riscv $(RUNTIME)" >> $(DST_TEST_SCRIPT) ;\
+		echo '[ $$? -eq 0 ] || echo "... ERROR"'         >> $(DST_TEST_SCRIPT) ;\
 	)
-	chmod +x test
+	chmod +x $(DST_TEST_SCRIPT)
+
+$(DST_RUNNER): $(DST_OBJS) $(SDK_HOST_LIB) $(SDK_EDGE_LIB) $(SDK_VERIFIER_LIB)
+	$(CC) $(CCFLAGS) $(LDFLAGS) -o $(DST_RUNNER) $^
 
 $(SDK_HOST_LIB):
 	$(MAKE) -C $(SDK_HOST_DIR)
 
-$(OBJS): %.o: %.cpp
-	$(CC) $(CCFLAGS) -c $<
+$(DST_OBJS): $(O)/%.o: %.cpp
+	@mkdir -p $(O)
+	$(CC) $(CCFLAGS) -c $< -o $@
 
 clean:
-	rm -f *.o *.riscv test
+	rm -f $(DST_OBJS) $(DST_RUNNER) $(DST_TEST_SCRIPT)
 	$(foreach test, $(TESTS), \
-		$(MAKE) -C $(test) clean; \
+		$(MAKE) -C $(test) O=$(O)/$(test) clean; \
 	)
+	rm -d $(O) 2>&1 || true

--- a/tests/tests/app.mk
+++ b/tests/tests/app.mk
@@ -1,29 +1,44 @@
-CC = riscv64-unknown-linux-gnu-gcc
-CFLAGS = -Wall -Werror
-LINK = riscv64-unknown-linux-gnu-ld
-AS = riscv64-unknown-linux-gnu-as
+CC := riscv64-unknown-linux-gnu-gcc
+CFLAGS := -Wall -Werror
+LINK := riscv64-unknown-linux-gnu-ld
+AS := riscv64-unknown-linux-gnu-as
 
-SDK_LIB_DIR = $(KEYSTONE_SDK_DIR)/lib
-SDK_APP_LIB = $(SDK_LIB_DIR)/libkeystone-eapp.a
-SDK_INCLUDE_DIR = $(SDK_LIB_DIR)/app/include
+O := $(shell pwd)
 
-LDFLAGS = -static -L$(SDK_LIB_DIR) -lkeystone-eapp
+SDK_LIB_DIR := $(KEYSTONE_SDK_DIR)/lib
+SDK_APP_LIB := $(SDK_LIB_DIR)/libkeystone-eapp.a
+SDK_INCLUDE_DIR := $(SDK_LIB_DIR)/app/include
+SDK_INCLUDE_EDGE_DIR = $(SDK_LIB_DIR)/edge/include
+
+LDFLAGS := -static -L$(SDK_LIB_DIR) -lkeystone-eapp
 CFLAGS += -I$(SDK_INCLUDE_DIR)
 
-APP_C_OBJS = $(patsubst %.c,%.o, $(APP_C_SRCS))
-APP_A_OBJS = $(patsubst %.s,%.o, $(APP_A_SRCS))
+APP_C_OBJS := $(patsubst %.c,%.o, $(APP_C_SRCS))
+APP_A_OBJS := $(patsubst %.s,%.o, $(APP_A_SRCS))
 APP_LDS ?= ../app.lds
 
-APP_BIN = $(patsubst %,%.eapp_riscv,$(APP))
+APP_BIN := $(patsubst %,%.eapp_riscv,$(APP))
 
-all: $(APP_BIN)
+APP_C_DST_OBJS := $(addprefix $(O)/,$(APP_C_OBJS))
+APP_A_DST_OBJS := $(addprefix $(O)/,$(APP_A_OBJS))
+APP_DST_BIN := $(O)/$(APP_BIN)
 
-$(APP_C_OBJS): %.o: %.c
-	$(CC) $(CFLAGS) -c $<
+.PHONY: all clean
 
-$(APP_BIN): %.eapp_riscv : $(APP_C_OBJS) $(APP_A_OBJS) $(SDK_APP_LIB)
+all: $(APP_DST_BIN)
+
+$(APP_C_DST_OBJS): $(O)/%.o: %.c
+	@mkdir -p $(O)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(APP_A_DST_OBJS): $(O)/%.o: %.s
+	@mkdir -p $(O)
+	$(AS) -c $< -o $@
+
+$(APP_DST_BIN): %.eapp_riscv : $(APP_C_DST_OBJS) $(APP_A_DST_OBJS) $(SDK_APP_LIB)
 	$(LINK) $(LDFLAGS) -o $@ $^ -T $(APP_LDS)
 	chmod -x $@
 
 clean:
-	rm -f *.o $(APP_BIN) $(EXTRA_CLEAN)
+	rm -f $(APP_C_DST_OBJS) $(APP_A_DST_OBJS) $(APP_DST_BIN) $(EXTRA_CLEAN)
+	rm -d $(O) 2>&1 || true

--- a/tests/tests/attestation/Makefile
+++ b/tests/tests/attestation/Makefile
@@ -1,35 +1,5 @@
 APP = attestation
 APP_C_SRCS= attestation.c edge_wrapper.c
+include ../app.mk
 
-CC = riscv64-unknown-linux-gnu-gcc
-CFLAGS = -Wall -Werror
-LINK = riscv64-unknown-linux-gnu-ld
-AS = riscv64-unknown-linux-gnu-as
-
-SDK_LIB_DIR = $(KEYSTONE_SDK_DIR)/lib
-SDK_APP_LIB = $(SDK_LIB_DIR)/libkeystone-eapp.a
-SDK_EDGE_LIB = $(SDK_LIB_DIR)/libkeystone-edge.a
-SDK_INCLUDE_APP_DIR = $(SDK_LIB_DIR)/app/include
-SDK_INCLUDE_EDGE_DIR = $(SDK_LIB_DIR)/edge/include
-
-LDFLAGS = -static -L$(SDK_LIB_DIR)
-CFLAGS += -I$(SDK_INCLUDE_APP_DIR) -I$(SDK_INCLUDE_EDGE_DIR)
-
-APP_C_OBJS = $(patsubst %.c,%.o, $(APP_C_SRCS))
-APP_A_OBJS = $(patsubst %.s,%.o, $(APP_A_SRCS))
-APP_LDS ?= ../app.lds
-
-APP_BIN = $(patsubst %,%.eapp_riscv,$(APP))
-
-all: $(APP_BIN)
-
-$(APP_C_OBJS): %.o: %.c
-	$(CC) $(CFLAGS) -c $<
-
-$(APP_BIN): %.eapp_riscv : $(APP_C_OBJS) $(APP_A_OBJS) $(SDK_APP_LIB) $(SDK_EDGE_LIB)
-	$(LINK) $(LDFLAGS) -o $@ $^ -T $(APP_LDS)
-	chmod -x $@
-
-clean:
-	rm -f *.o $(APP_BIN) $(EXTRA_CLEAN)
-
+CFLAGS += -I$(SDK_INCLUDE_EDGE_DIR)

--- a/tests/tests/untrusted/Makefile
+++ b/tests/tests/untrusted/Makefile
@@ -1,35 +1,5 @@
 APP = untrusted
 APP_C_SRCS= untrusted.c edge_wrapper.c
+include ../app.mk
 
-CC = riscv64-unknown-linux-gnu-gcc
-CFLAGS = -Wall -Werror
-LINK = riscv64-unknown-linux-gnu-ld
-AS = riscv64-unknown-linux-gnu-as
-
-SDK_LIB_DIR = $(KEYSTONE_SDK_DIR)/lib
-SDK_APP_LIB = $(SDK_LIB_DIR)/libkeystone-eapp.a
-SDK_EDGE_LIB = $(SDK_LIB_DIR)/libkeystone-edge.a
-SDK_INCLUDE_APP_DIR = $(SDK_LIB_DIR)/app/include
-SDK_INCLUDE_EDGE_DIR = $(SDK_LIB_DIR)/edge/include
-
-LDFLAGS = -static -L$(SDK_LIB_DIR)
-CFLAGS += -I$(SDK_INCLUDE_APP_DIR) -I$(SDK_INCLUDE_EDGE_DIR)
-
-APP_C_OBJS = $(patsubst %.c,%.o, $(APP_C_SRCS))
-APP_A_OBJS = $(patsubst %.s,%.o, $(APP_A_SRCS))
-APP_LDS ?= ../app.lds
-
-APP_BIN = $(patsubst %,%.eapp_riscv,$(APP))
-
-all: $(APP_BIN)
-
-$(APP_C_OBJS): %.o: %.c
-	$(CC) $(CFLAGS) -c $<
-
-$(APP_BIN): %.eapp_riscv : $(APP_C_OBJS) $(APP_A_OBJS) $(SDK_APP_LIB) $(SDK_EDGE_LIB)
-	$(LINK) $(LDFLAGS) -o $@ $^ -T $(APP_LDS)
-	chmod -x $@
-
-clean:
-	rm -f *.o $(APP_BIN) $(EXTRA_CLEAN)
-
+CFLAGS += -I$(SDK_INCLUDE_EDGE_DIR)

--- a/tests/tests/vault.sh
+++ b/tests/tests/vault.sh
@@ -6,7 +6,8 @@ set -e
 ################################################################
 NAME=tests
 VAULT_DIR=$(cd `dirname $0` && pwd)
-BUILD_COMMAND=make
+ARTIFACTS_DIR=${ARTIFACTS_DIR:=.}
+BUILD_COMMAND="make -C \"$VAULT_DIR\" O=\"$ARTIFACTS_DIR\""
 OUTPUT_DIR=${OUTPUT_DIR:=$VAULT_DIR/../../buildroot_overlay/root/$NAME}
 EYRIE_DIR=$KEYSTONE_SDK_DIR/rts/eyrie
 EYRIE_PLUGINS="freemem"
@@ -73,8 +74,8 @@ mkdir -p $OUTPUT_FILES_DIR
 $EYRIE_DIR/build.sh $EYRIE_PLUGINS
 
 # build the app
-pushd $VAULT_DIR
-$BUILD_COMMAND
+pushd $ARTIFACTS_DIR
+eval "$BUILD_COMMAND"
 for output in $PACKAGE_FILES; do
   cp $output $OUTPUT_FILES_DIR
 done


### PR DESCRIPTION
Just a few build system improvements.

WRT the CMake stuff, `set(... CACHE)` is better practice for variables designed to be modified by the user. If you use a tool like `ccmake` (a very useful cmake TUI!) these are the variables that show up.

I also made the tests/tests directory run out of tree builds, to make it easy to wipe away build artifacts. I also changed the Makefile lazy assignments (using `foo = bar`) to use eager ones (`foo := bar`). This is much faster because the right hand side is only expanded once, at assignment time.