### PR TITLE
Ensure KEYSTONE_SDK_DIR is both set and present in fast-setup.sh

### DIFF
--- a/fast-setup.sh
+++ b/fast-setup.sh
@@ -74,9 +74,11 @@ git submodule sync --recursive
 git submodule update --init --recursive
 
 # build SDK if not present
-if [ -z $KEYSTONE_SDK_DIR ]
+if [ ! -z $KEYSTONE_SDK_DIR ] && [ -e $KEYSTONE_SDK_DIR ]
 then
-  echo "KEYSTONE_SDK_DIR is not set. Installing from $(pwd)/sdk"
+  echo "KEYSTONE_SDK_DIR is set to $KEYSTONE_SDK_DIR and present. Skipping SDK installation."
+else
+  echo "KEYSTONE_SDK_DIR is not set or present. Installing from $(pwd)/sdk"
   export KEYSTONE_SDK_DIR=$(pwd)/sdk/build$BITS
   cd sdk
   mkdir -p build


### PR DESCRIPTION
Ensure KEYSTONE_SDK_DIR is both set and present in fast-setup.sh. The current check only ensures KEYSTONE_SDK_DIR is set, which may cause builds to fail when someone wanted to start fresh by resetting the local git repo but forgot the unset  KEYSTONE_SDK_DIR. This is one cause for keystone-enclave#236 which I ran into.