### PR TITLE
Update to documentation on testing.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,12 @@ make html
 You can locally host the built doc by running
 
 ```
-python -m SimpleHTTPServer
+python2 -m SimpleHTTPServer
+```
+
+or
+
+```
+python3 -m http.server
 ```
 

--- a/docs/source/Getting-Started/QEMU-Compile-Sources.rst
+++ b/docs/source/Getting-Started/QEMU-Compile-Sources.rst
@@ -24,7 +24,7 @@ Here are some useful CMake flags you can add:
 * ``-DSM_PLATFORM=<platform>``: The security monitor will be compiled with platform sources in ``sm/plat/<platform>``. The default value is "generic".
 * ``-DUSE_RUST_SM=y``: Use the Rust port of the security monitor. Curently not supported in v1.0.
 
-In order to build the driver and the tests, and have the final images for QEMU, you need to run
+In order to build the driver and have the final images for QEMU, you need to run
 
 ::
 
@@ -112,19 +112,6 @@ The following command will build the linux driver for Keystone.
 
   # in your <build directory>
   make driver
-
-Build Tests
-##############################################################
-
-The tests are a part of Keystone SDK's example enclaves.
-Thus, we build them using ``sdk/examples/CMakeLists.txt``.
-
-The following command will build the tests and copy the package into the buildroot overlay directory.
-
-::
-
-  # in your <build directory>
-  make tests
 
 Updating Images
 ##############################################################

--- a/docs/source/Getting-Started/QEMU-Compile-Sources.rst
+++ b/docs/source/Getting-Started/QEMU-Compile-Sources.rst
@@ -69,10 +69,11 @@ Build Linux Kernel
 ##############################################################
 
 Kernel config files are located at ``conf/``. RV64 linux will use ``conf/linux-v5.0-defconfig-rv64``.
-The following command will build the linux
+The following command will build the linux.
+Note that you need at least 2GB of memory in order to successfully build the kernel.
 
 Keystone requires patches for the Linux kernel to reserve CMA region at boot.
-The patch is located at ``patches/linux/``
+The patch is located at ``patches/linux/``.
 
 ::
 

--- a/docs/source/Getting-Started/QEMU-Run-Tests.rst
+++ b/docs/source/Getting-Started/QEMU-Run-Tests.rst
@@ -18,7 +18,7 @@ If you wish to compile and run tests by your self, follow the following instruct
 Build Test Binaries
 #############################
 
-Test enclaves are a part of Keysonte SDK's examples.
+Keystone tests leverage packages built as part of Keysonte SDK's examples.
 You can build the tests by executing ``make tests``.
 Note that ``KEYSTONE_SDK_DIR`` must be set to the install path of the SDK.
 
@@ -26,17 +26,29 @@ Note that ``KEYSTONE_SDK_DIR`` must be set to the install path of the SDK.
 
   make tests
 
-This command will build the enclave package named ``tests.ke``
-and copy it into ``<build directory>/overlay`` directory.
+This command will build a few enclave packages named ``*.ke`` in the ``<build directory>/example`` directory.
+
+Next, you need to copy the enclave packages into the disk image that you're going to boot on.
+We use `Buildroot Overlay <https://buildroot.org/downloads/manual/manual.html#rootfs-custom>`_ for injecting the test binaries into the disk image.
+The buildroot overlay directory is ``<build directory>/overlay``.
+
+We need to copy the packages into the ``<build directory>/overlay`` directory and re-generate the QEMU image:
+
+::
+
+   find ./examples/ -name '*.ke' -exec cp \{\} ./overlay/root/ \;
+
+The ``attestor.ke`` example requires the Security Monitor binary also located under ``/root``, so let's copy the Security Monitor binary as well:
+
+::
+
+   cp sm.build/platform/generic/firmware/fw_payload.bin overlay/root/
+
 
 Build Disk Image
 #############################
 
-Next, you need to copy the enclave package into the disk image that you're going to boot on.
-
-We use `Buildroot Overlay <https://buildroot.org/downloads/manual/manual.html#rootfs-custom>`_ for
-injecting the test binaries into the disk image.
-The buildroot overlay directory is ``<build directory>/overlay``.
+Now it's time to re-generate the QEMU image:
 
 ::
 
@@ -89,3 +101,5 @@ In order to extract the package without execution, run
   ./tests.ke --noexec --target <dst>
 
 Run ``./tests.ke --help`` for more information.
+
+You can run other examples such as ``attestor.ke`` as well. See :doc:`Tutorials<Tutorials/index>` for a list of tutorials related to these examples.

--- a/docs/source/Getting-Started/Running-Keystone-on-Hardware.rst
+++ b/docs/source/Getting-Started/Running-Keystone-on-Hardware.rst
@@ -6,14 +6,14 @@ board (referred to as HiFive for the rest of this document) with an
 FU540 chip.
 
 
-Building Keystone 
+Building Keystone
 ----------------------------------------
 
 Building for the HiFive is straight-forward.
 First, clone the Keystone repository in the **manager instance**.
 
 ::
-  
+
   git clone https://github.com/keystone-enclave/keystone
 
 Follow :doc:`QEMU-Setup-Repository` to setup the repository.
@@ -21,7 +21,7 @@ Follow :doc:`QEMU-Setup-Repository` to setup the repository.
 After you setup the repository, you can run the following commands to build Keystone.
 
 ::
-  
+
   mkdir <build directory>
   cd <build directory>
   cmake .. -DLINUX_SIFIVE=y
@@ -153,4 +153,4 @@ Example
 ::
 
    insmod keystone-driver.ko
-   ./tests/tests.ke
+   ./tests.ke

--- a/docs/source/Getting-Started/Tutorials/Build-Enclave-App-Hello-World.rst
+++ b/docs/source/Getting-Started/Tutorials/Build-Enclave-App-Hello-World.rst
@@ -130,7 +130,7 @@ Next, copy the package into the buildroot overlay directory.
 ::
 
   # in the build directory
-  cp examples/hello ./overlay/root
+  cp examples/hello/hello.ke ./overlay/root
 
 Running ``make image`` in your build directory will generate the buildroot disk
 image containing the copied package.
@@ -161,7 +161,7 @@ Deploy the enclave
 ::
 
 	# [inside QEMU]
-	./hello/hello.ke
+	./hello.ke
 
 You'll see the enclave running!
 

--- a/docs/source/Getting-Started/Tutorials/Remote-Attestation.rst
+++ b/docs/source/Getting-Started/Tutorials/Remote-Attestation.rst
@@ -159,7 +159,9 @@ verifier.
 
 While 1 and 2 are typically done beforehand (or delegated to a trusted
 party), 3-5 are done at runtime by checking signature and payload of
-the attestation report.
+the attestation report. See
+:doc:`Attestation<../../Keystone-Applications/Attestation>` for
+additional details on Keystone's attestation support.
 
 The ``Verifier::verify_report`` method accomplishes 3-5:
 
@@ -294,12 +296,13 @@ In order to build the example, try the following in the build directory:
 This will generate an enclave package named ``attestor.ke`` under ``<build directory>/examples/attestation``.
 ``attestor.ke`` is an self-extracting archive file for the enclave.
 
-Next, copy the package into the buildroot overlay directory.
+Next, copy the package and the Security Monitor binary into the buildroot overlay directory.
 
 ::
 
   # in the build directory
-  cp examples/attestation ./overlay/root
+  cp examples/attestation/attestor.ke ./overlay/root
+  cp sm.build/platform/generic/firmware/fw_payload.bin overlay/root/
 
 Running ``make image`` in your build directory will generate the buildroot disk
 image containing the copied package.
@@ -330,7 +333,7 @@ Deploy the enclave
 ::
 
 	# [inside QEMU]
-	./attestation/attestor.ke
+	./attestor.ke
 
 You'll see the enclave running!
 

--- a/docs/source/Getting-Started/index.rst
+++ b/docs/source/Getting-Started/index.rst
@@ -6,7 +6,7 @@ What is Keystone?
 
 Keystone is an open-source TEE framework for RISC-V processors.
 
-You can currently try Keystone on qemu, `FireSim <https://fires.im/>`_ (FPGA), or the SiFive `HiFive Unleashed <https://www.sifive.com/boards/hifive-unleashed>`_ board.
+You can currently try Keystone on `QEMU <https://www.qemu.org/>`_, `FireSim <https://fires.im/>`_ (FPGA), or the SiFive `HiFive Unleashed <https://www.sifive.com/boards/hifive-unleashed>`_ board.
 
 You can migrate the Keystone enclave into arbitrary RISC-V processor, with a very small modification on hardware to plant the silicon root of trust.
 
@@ -18,7 +18,7 @@ You can migrate the Keystone enclave into arbitrary RISC-V processor, with a ver
 
   The current version (0.X) of Keystone is not formally verified, nor matured.
   We recommend you to use Keystone only for research purposes until it gets stablized.
-  We appreciate any contribution for making Keystone better.
+  We appreciate any :doc:`contribution<../Contributing-to-Keystone/How-to-Contribute>` for making Keystone better.
 
 
 Quick Start
@@ -40,6 +40,7 @@ Tutorials
 
 * :doc:`Hello world with libc<Tutorials/Build-Enclave-App-Hello-World>`
 * :doc:`Hello world without libc<Tutorials/Build-Enclave-App-Hello-World-Native>`
+* :doc:`Remote Attestation<Tutorials/Remote-Attestation>`
 
 
 Keystone Demo


### PR DESCRIPTION
With tests no longer being a dependency of image, folks need to
explicitly copy the test packages before running `make image`. Update
various documents about that.

Related issues: #251, #252