### PR TITLE
Build new cmake-based Eyrie

### DIFF
--- a/sdk/examples/hello/CMakeLists.txt
+++ b/sdk/examples/hello/CMakeLists.txt
@@ -6,9 +6,9 @@ set(package_name "hello.ke")
 set(package_script "./hello-runner hello eyrie-rt")
 
 if(RISCV32)
-  set(eyrie_plugins "freemem untrusted_io_syscall linux_syscall env_setup rv32")
+  set(eyrie_plugins "freemem io_syscall linux_syscall env_setup rv32")
 else()
-  set(eyrie_plugins "freemem untrusted_io_syscall linux_syscall env_setup")
+  set(eyrie_plugins "freemem io_syscall linux_syscall env_setup")
 endif()
 
 # eapp

--- a/sdk/macros.cmake
+++ b/sdk/macros.cmake
@@ -85,14 +85,23 @@ macro(add_eyrie_runtime target_name tag plugins) # the files are passed via ${AR
   set(runtime_prefix runtime)
   set (eyrie_src ${CMAKE_CURRENT_BINARY_DIR}/${runtime_prefix}/src/eyrie-${target_name})
 
+  separate_arguments(PLUGIN_ARGS UNIX_COMMAND ${plugins})
+  set(PLUGIN_FLAGS "")
+  foreach(plugin IN ITEMS ${PLUGIN_ARGS})
+    string(TOUPPER ${plugin} PLUGIN_UPPER)
+    list(APPEND PLUGIN_FLAGS "-D${PLUGIN_UPPER}=ON")
+  endforeach()
+
+  list(APPEND PLUGIN_FLAGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}")
+
   ExternalProject_Add(eyrie-${target_name}
     PREFIX ${runtime_prefix}
     GIT_REPOSITORY https://github.com/keystone-enclave/keystone-runtime
     GIT_TAG ${tag}
-    CONFIGURE_COMMAND ""
     UPDATE_COMMAND git fetch
-    BUILD_COMMAND ./build.sh ${plugins}
+    CMAKE_ARGS ${PLUGIN_FLAGS}
     BUILD_IN_SOURCE TRUE
+    BUILD_BYPRODUCTS ${eyrie_src}/eyrie-rt ${eyrie_src}/.options_log
     INSTALL_COMMAND "")
 
   add_custom_target(${target_name} DEPENDS ${ARGN})

--- a/sdk/macros.cmake
+++ b/sdk/macros.cmake
@@ -99,7 +99,7 @@ macro(add_eyrie_runtime target_name tag plugins) # the files are passed via ${AR
     GIT_REPOSITORY https://github.com/keystone-enclave/keystone-runtime
     GIT_TAG ${tag}
     UPDATE_COMMAND git fetch
-    CMAKE_ARGS ${PLUGIN_FLAGS}
+    CMAKE_ARGS "${PLUGIN_FLAGS}"
     BUILD_IN_SOURCE TRUE
     BUILD_BYPRODUCTS ${eyrie_src}/eyrie-rt ${eyrie_src}/.options_log
     INSTALL_COMMAND "")


### PR DESCRIPTION
This PR slightly changes the `add_eyrie_runtime` macro in order to accommodate the new Cmake-based runtime build (https://github.com/keystone-enclave/keystone-runtime/pull/63)