### PR TITLE
Update Dockerfiles (ubuntu 20.04)

### DIFF
--- a/docker/Dockerfile.32.nobuild
+++ b/docker/Dockerfile.32.nobuild
@@ -16,14 +16,6 @@ RUN git clone https://github.com/keystone-enclave/keystone /keystone
 RUN cd /keystone && \
     git checkout $CHECKOUT && \
     rmdir linux qemu buildroot && \
-    ./fast-setup.sh && \
-    . ./source.sh && \
-    rm -rf firesim-riscv-tools-prebuilt-* && \
-    rm -f 2.0.tar.gz && \
-    rm -f build && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make -j$(nproc)
+    BITS=32 ./fast-setup.sh
 
-ENTRYPOINT cd /keystone && . ./source.sh && cd /keystone/build && make run-tests
+ENTRYPOINT cd /keystone && . ./source.sh

--- a/docker/Dockerfile.nobuild
+++ b/docker/Dockerfile.nobuild
@@ -16,14 +16,6 @@ RUN git clone https://github.com/keystone-enclave/keystone /keystone
 RUN cd /keystone && \
     git checkout $CHECKOUT && \
     rmdir linux qemu buildroot && \
-    ./fast-setup.sh && \
-    . ./source.sh && \
-    rm -rf firesim-riscv-tools-prebuilt-* && \
-    rm -f 2.0.tar.gz && \
-    rm -f build && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make -j$(nproc)
+    ./fast-setup.sh
 
-ENTRYPOINT cd /keystone && . ./source.sh && cd /keystone/build && make run-tests
+ENTRYPOINT cd /keystone && . ./source.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,8 +2,9 @@
 
 To build the image with master branch:
 ```bash
-docker build -t keystoneenclaveorg/keystone:master
+docker build -t keystoneenclaveorg/keystone:master .
 ```
+
 
 dev branch:
 
@@ -14,4 +15,19 @@ docker build -t keystoneenclaveorg/keystone:dev --build-arg CHECKOUT=dev .
 any other branches or tags:
 ```bash
 docker build -t keystoneenclaveorg/keystone:<tag> --build-arg CHECKOUT=<tag> .
+```
+
+# Building CI images
+
+RV64:
+```
+docker build -t keystoneenclaveorg/keystone:init-rv64gc --build-arg CHECKOUT=master . --platform linux/x86_64 -f Dockerfile.nobuild
+docker push keystoneenclaveorg/keystone:init-rv64gc
+```
+
+RV32:
+
+```
+docker build -t keystoneenclaveorg/keystone:init-rv32gc --build-arg CHECKOUT=master . --platform linux/x86_64 -f Dockerfile.32.nobuild
+docker push keystoneenclaveorg/keystone:init-rv32gc
 ```


### PR DESCRIPTION
Dockerfile was outdated, so update it to Ubuntu 20.04 first.
Also, add a few packages that were missing.

