### PR TITLE
Feature/cmake eyrie

### DIFF
--- a/sdk/examples/attestation/CMakeLists.txt
+++ b/sdk/examples/attestation/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(${host_bin}
 
 set(eyrie_files_to_copy .options_log eyrie-rt)
 add_eyrie_runtime(${eapp_bin}-eyrie
-  "v1.1.0"
+  "v1.2.0"
   ${eyrie_plugins}
   ${eyrie_files_to_copy})
 

--- a/sdk/examples/attestation/CMakeLists.txt
+++ b/sdk/examples/attestation/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(${host_bin}
 
 set(eyrie_files_to_copy .options_log eyrie-rt)
 add_eyrie_runtime(${eapp_bin}-eyrie
-  "v1.2.0"
+  "v1.2.1"
   ${eyrie_plugins}
   ${eyrie_files_to_copy})
 

--- a/sdk/examples/hello-native/CMakeLists.txt
+++ b/sdk/examples/hello-native/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(${host_bin}
 
 set(eyrie_files_to_copy .options_log eyrie-rt)
 add_eyrie_runtime(${eapp_bin}-eyrie
-  "v1.1.0"
+  "v1.2.0"
   ${eyrie_plugins}
   ${eyrie_files_to_copy})
 

--- a/sdk/examples/hello-native/CMakeLists.txt
+++ b/sdk/examples/hello-native/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(${host_bin}
 
 set(eyrie_files_to_copy .options_log eyrie-rt)
 add_eyrie_runtime(${eapp_bin}-eyrie
-  "v1.2.0"
+  "v1.2.1"
   ${eyrie_plugins}
   ${eyrie_files_to_copy})
 

--- a/sdk/examples/hello/CMakeLists.txt
+++ b/sdk/examples/hello/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(${host_bin} ${KEYSTONE_LIB_HOST} ${KEYSTONE_LIB_EDGE})
 
 set(eyrie_files_to_copy .options_log eyrie-rt)
 add_eyrie_runtime(${eapp_bin}-eyrie
-  "v1.2.0"
+  "v1.2.1"
   ${eyrie_plugins}
   ${eyrie_files_to_copy})
 

--- a/sdk/examples/hello/CMakeLists.txt
+++ b/sdk/examples/hello/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(${host_bin} ${KEYSTONE_LIB_HOST} ${KEYSTONE_LIB_EDGE})
 
 set(eyrie_files_to_copy .options_log eyrie-rt)
 add_eyrie_runtime(${eapp_bin}-eyrie
-  "v1.1.0"
+  "v1.2.0"
   ${eyrie_plugins}
   ${eyrie_files_to_copy})
 

--- a/sdk/examples/hello/CMakeLists.txt
+++ b/sdk/examples/hello/CMakeLists.txt
@@ -6,9 +6,9 @@ set(package_name "hello.ke")
 set(package_script "./hello-runner hello eyrie-rt")
 
 if(RISCV32)
-  set(eyrie_plugins "freemem untrusted_io_syscall linux_syscall env_setup rv32")
+  set(eyrie_plugins "freemem io_syscall linux_syscall env_setup rv32")
 else()
-  set(eyrie_plugins "freemem untrusted_io_syscall linux_syscall env_setup")
+  set(eyrie_plugins "freemem io_syscall linux_syscall env_setup")
 endif()
 
 # eapp

--- a/sdk/examples/tests/CMakeLists.txt
+++ b/sdk/examples/tests/CMakeLists.txt
@@ -104,7 +104,7 @@ target_link_libraries(${host_bin} ${KEYSTONE_LIB_HOST} ${KEYSTONE_LIB_EDGE} ${KE
 
 set(eyrie_files_to_copy .options_log eyrie-rt)
 add_eyrie_runtime(test-eyrie
-  "v1.1.0"
+  "v1.2.0"
   ${eyrie_plugins}
   ${eyrie_files_to_copy})
 

--- a/sdk/examples/tests/CMakeLists.txt
+++ b/sdk/examples/tests/CMakeLists.txt
@@ -104,7 +104,7 @@ target_link_libraries(${host_bin} ${KEYSTONE_LIB_HOST} ${KEYSTONE_LIB_EDGE} ${KE
 
 set(eyrie_files_to_copy .options_log eyrie-rt)
 add_eyrie_runtime(test-eyrie
-  "v1.2.0"
+  "v1.2.1"
   ${eyrie_plugins}
   ${eyrie_files_to_copy})
 

--- a/sdk/macros.cmake
+++ b/sdk/macros.cmake
@@ -85,14 +85,23 @@ macro(add_eyrie_runtime target_name tag plugins) # the files are passed via ${AR
   set(runtime_prefix runtime)
   set (eyrie_src ${CMAKE_CURRENT_BINARY_DIR}/${runtime_prefix}/src/eyrie-${target_name})
 
+  separate_arguments(PLUGIN_ARGS UNIX_COMMAND ${plugins})
+  set(PLUGIN_FLAGS "")
+  foreach(plugin IN ITEMS ${PLUGIN_ARGS})
+    string(TOUPPER ${plugin} PLUGIN_UPPER)
+    list(APPEND PLUGIN_FLAGS "-D${PLUGIN_UPPER}=ON")
+  endforeach()
+
+  list(APPEND PLUGIN_FLAGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}")
+
   ExternalProject_Add(eyrie-${target_name}
     PREFIX ${runtime_prefix}
     GIT_REPOSITORY https://github.com/keystone-enclave/keystone-runtime
     GIT_TAG ${tag}
-    CONFIGURE_COMMAND ""
     UPDATE_COMMAND git fetch
-    BUILD_COMMAND ./build.sh ${plugins}
+    CMAKE_ARGS ${PLUGIN_FLAGS}
     BUILD_IN_SOURCE TRUE
+    BUILD_BYPRODUCTS ${eyrie_src}/eyrie-rt ${eyrie_src}/.options_log
     INSTALL_COMMAND "")
 
   add_custom_target(${target_name} DEPENDS ${ARGN})

--- a/sdk/macros.cmake
+++ b/sdk/macros.cmake
@@ -93,6 +93,7 @@ macro(add_eyrie_runtime target_name tag plugins) # the files are passed via ${AR
   endforeach()
 
   list(APPEND PLUGIN_FLAGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}")
+  list(APPEND PLUGIN_FLAGS "-DCMAKE_OBJCOPY=${CMAKE_OBJCOPY}")
 
   ExternalProject_Add(eyrie-${target_name}
     PREFIX ${runtime_prefix}

--- a/sdk/macros.cmake
+++ b/sdk/macros.cmake
@@ -99,7 +99,7 @@ macro(add_eyrie_runtime target_name tag plugins) # the files are passed via ${AR
     GIT_REPOSITORY https://github.com/keystone-enclave/keystone-runtime
     GIT_TAG ${tag}
     UPDATE_COMMAND git fetch
-    CMAKE_ARGS ${PLUGIN_FLAGS}
+    CMAKE_ARGS "${PLUGIN_FLAGS}"
     BUILD_IN_SOURCE TRUE
     BUILD_BYPRODUCTS ${eyrie_src}/eyrie-rt ${eyrie_src}/.options_log
     INSTALL_COMMAND "")


### PR DESCRIPTION
This PR slightly changes the add_eyrie_runtime macro in order to accommodate the new Cmake-based runtime build (https://github.com/keystone-enclave/keystone-runtime/pull/64)