### PR TITLE
Add basic code quality improvements to SDK/host

### DIFF
--- a/sdk/include/host/ElfFile.hpp
+++ b/sdk/include/host/ElfFile.hpp
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include <iostream>
 #include <string>
+#include <cstdint>
 #include "./common.h"
 #include "./keystone_user.h"
 
@@ -21,33 +22,33 @@ class ElfFile {
  public:
   explicit ElfFile(std::string filename);
   ~ElfFile();
-  size_t getFileSize() { return fileSize; }
-  bool isValid();
+  std::size_t getFileSize() const noexcept { return fileSize; }
+  bool isValid() const noexcept;
 
-  uintptr_t getMinVaddr() { return minVaddr; }
-  size_t getTotalMemorySize() { return maxVaddr - minVaddr; }
+  std::uintptr_t getMinVaddr() const noexcept { return minVaddr; }
+  std::size_t getTotalMemorySize() const noexcept { return maxVaddr - minVaddr; }
   bool initialize(bool isRuntime);
 
-  unsigned int getPageMode() { return (isRuntime ? RT_FULL : USER_FULL); }
+  unsigned int getPageMode() const noexcept { return (isRuntime ? RT_FULL : USER_FULL); }
 
   /* libelf wrapper function */
-  size_t getNumProgramHeaders(void);
-  size_t getProgramHeaderType(size_t ph);
-  size_t getProgramHeaderFileSize(size_t ph);
-  size_t getProgramHeaderMemorySize(size_t ph);
-  uintptr_t getProgramHeaderVaddr(size_t ph);
-  uintptr_t getEntryPoint();
-  void* getProgramSegment(size_t ph);
+  std::size_t getNumProgramHeaders(void);
+  std::size_t getProgramHeaderType(std::size_t ph);
+  std::size_t getProgramHeaderFileSize(std::size_t ph);
+  std::size_t getProgramHeaderMemorySize(std::size_t ph);
+  std::uintptr_t getProgramHeaderVaddr(std::size_t ph);
+  std::uintptr_t getEntryPoint();
+  void* getProgramSegment(std::size_t ph);
 
  private:
   int filep;
 
   /* virtual addresses */
-  uintptr_t minVaddr;
-  uintptr_t maxVaddr;
+  std::uintptr_t minVaddr;
+  std::uintptr_t maxVaddr;
 
   void* ptr;
-  size_t fileSize;
+  std::size_t fileSize;
 
   /* is this runtime binary */
   bool isRuntime;

--- a/sdk/include/host/Enclave.hpp
+++ b/sdk/include/host/Enclave.hpp
@@ -12,10 +12,10 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <iostream>
-#include <cstdint>
 
 #include "./common.h"
 extern "C" {

--- a/sdk/include/host/Enclave.hpp
+++ b/sdk/include/host/Enclave.hpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <functional>
 #include <iostream>
+#include <cstdint>
 
 #include "./common.h"
 extern "C" {
@@ -28,7 +29,7 @@ extern "C" {
 
 namespace Keystone {
 
-typedef std::function<void(void*)> OcallFunc;
+using OcallFunc = std::function<void(void*)>;
 
 class Enclave {
  private:
@@ -39,13 +40,13 @@ class Enclave {
   KeystoneDevice* pDevice;
   char hash[MDSIZE];
   hash_ctx_t hash_ctx;
-  uintptr_t runtime_stk_sz;
+  std::uintptr_t runtime_stk_sz;
   void* shared_buffer;
-  size_t shared_buffer_size;
+  std::size_t shared_buffer_size;
   OcallFunc oFuncDispatch;
-  bool mapUntrusted(size_t size);
-  bool allocPage(uintptr_t va, uintptr_t src, unsigned int mode);
-  bool initStack(uintptr_t start, size_t size, bool is_rt);
+  bool mapUntrusted(std::size_t size);
+  bool allocPage(std::uintptr_t va, std::uintptr_t src, unsigned int mode);
+  bool initStack(std::uintptr_t start, std::size_t size, bool is_rt);
   Error loadUntrusted();
   bool mapElf(ElfFile* file);
   Error loadElf(ElfFile* file);
@@ -53,27 +54,27 @@ class Enclave {
 
   bool initFiles(const char*, const char*);
   bool initDevice();
-  bool prepareEnclave(uintptr_t alternatePhysAddr);
+  bool prepareEnclave(std::uintptr_t alternatePhysAddr);
   bool initMemory();
 
  public:
   Enclave();
   ~Enclave();
-  const char* getHash();
-  void* getSharedBuffer();
-  size_t getSharedBufferSize();
+  const char* getHash() const noexcept;
+  void* getSharedBuffer() noexcept;
+  std::size_t getSharedBufferSize() const noexcept;
   Error registerOcallDispatch(OcallFunc func);
   Error init(const char* filepath, const char* runtime, Params parameters);
   Error init(
       const char* eapppath, const char* runtimepath, Params _params,
-      uintptr_t alternatePhysAddr);
+      std::uintptr_t alternatePhysAddr);
   Error destroy();
-  Error run(uintptr_t* ret = nullptr);
+  Error run(std::uintptr_t* ret = nullptr);
 };
 
-uint64_t
+std::uint64_t
 calculate_required_pages(
-    uint64_t eapp_sz, uint64_t eapp_stack_sz, uint64_t rt_sz,
-    uint64_t rt_stack_sz);
+    std::uint64_t eapp_sz, std::uint64_t eapp_stack_sz, std::uint64_t rt_sz,
+    std::uint64_t rt_stack_sz);
 
 }  // namespace Keystone

--- a/sdk/include/host/KeystoneDevice.hpp
+++ b/sdk/include/host/KeystoneDevice.hpp
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <cerrno>
 #include <cstring>
+#include <cstdint>
 #include <iostream>
 #include "./common.h"
 #include "./keystone_user.h"
@@ -23,28 +24,27 @@ namespace Keystone {
 
 class KeystoneDevice {
  protected:
-  int eid;
-  uintptr_t physAddr;
+  int eid{ -1 };
+  std::uintptr_t physAddr;
 
  private:
   int fd;
-  Error __run(bool resume, uintptr_t* ret);
+  Error __run(bool resume, std::uintptr_t* ret);
 
  public:
-  virtual uintptr_t getPhysAddr() { return physAddr; }
+  virtual std::uintptr_t getPhysAddr() { return physAddr; }
 
-  KeystoneDevice();
   virtual ~KeystoneDevice() {}
   virtual bool initDevice(Params params);
-  virtual Error create(uint64_t minPages);
-  virtual uintptr_t initUTM(size_t size);
+  virtual Error create(std::uint64_t minPages);
+  virtual std::uintptr_t initUTM(std::size_t size);
   virtual Error finalize(
-      uintptr_t runtimePhysAddr, uintptr_t eappPhysAddr, uintptr_t freePhysAddr,
+      std::uintptr_t runtimePhysAddr, std::uintptr_t eappPhysAddr, std::uintptr_t freePhysAddr,
       struct runtime_params_t params);
   virtual Error destroy();
-  virtual Error run(uintptr_t* ret);
-  virtual Error resume(uintptr_t* ret);
-  virtual void* map(uintptr_t addr, size_t size);
+  virtual Error run(std::uintptr_t* ret);
+  virtual Error resume(std::uintptr_t* ret);
+  virtual void* map(std::uintptr_t addr, std::size_t size);
 };
 
 class MockKeystoneDevice : public KeystoneDevice {
@@ -56,15 +56,15 @@ class MockKeystoneDevice : public KeystoneDevice {
   MockKeystoneDevice() {}
   ~MockKeystoneDevice();
   bool initDevice(Params params);
-  Error create(uint64_t minPages);
-  uintptr_t initUTM(size_t size);
+  Error create(std::uint64_t minPages);
+  std::uintptr_t initUTM(std::size_t size);
   Error finalize(
-      uintptr_t runtimePhysAddr, uintptr_t eappPhysAddr, uintptr_t freePhysAddr,
+      std::uintptr_t runtimePhysAddr, std::uintptr_t eappPhysAddr, std::uintptr_t freePhysAddr,
       struct runtime_params_t params);
   Error destroy();
-  Error run(uintptr_t* ret);
-  Error resume(uintptr_t* ret);
-  void* map(uintptr_t addr, size_t size);
+  Error run(std::uintptr_t* ret);
+  Error resume(std::uintptr_t* ret);
+  void* map(std::uintptr_t addr, std::size_t size);
 };
 
 }  // namespace Keystone

--- a/sdk/include/host/Params.hpp
+++ b/sdk/include/host/Params.hpp
@@ -4,61 +4,61 @@
 //------------------------------------------------------------------------------
 #pragma once
 
+#include <cstdint>
 #include <cstdio>
 
+namespace detail {
+namespace defaults {
+constexpr std::uint64_t untrusted_size = 8192;  // 8 KB
 #if __riscv_xlen == 64
-#define DEFAULT_FREEMEM_SIZE 1024 * 1024  // 1 MB
-#define DEFAULT_UNTRUSTED_PTR 0xffffffff80000000
-#define DEFAULT_STACK_SIZE 1024 * 16  // 16k
-#define DEFAULT_STACK_START 0x0000000040000000
+constexpr std::uint64_t freemem_size  = 1024 * 1024;  // 1 MB
+constexpr std::uint64_t stack_size    = 1024 * 16;    // 16k
+constexpr std::uint64_t stack_start   = 0x0000000040000000;
+constexpr std::uint64_t untrusted_ptr = 0xffffffff80000000;
 #elif __riscv_xlen == 32
-#define DEFAULT_FREEMEM_SIZE 1024 * 512  // 512 KiB
-#define DEFAULT_UNTRUSTED_PTR 0x80000000
-#define DEFAULT_STACK_SIZE 1024 * 8  // 3 KiB
-#define DEFAULT_STACK_START 0x40000000
-#else                                     // for x86 tests
-#define DEFAULT_FREEMEM_SIZE 1024 * 1024  // 1 MB
-#define DEFAULT_UNTRUSTED_PTR 0xffffffff80000000
-#define DEFAULT_STACK_SIZE 1024 * 16  // 16k
-#define DEFAULT_STACK_START 0x0000000040000000
+constexpr std::uint64_t freemem_size  = 1024 * 512;  // 512 KiB
+constexpr std::uint64_t stack_size    = 1024 * 8;    // 3 KiB
+constexpr std::uint64_t stack_start   = 0x40000000;
+constexpr std::uint64_t untrusted_ptr = 0x80000000;
+#else
+constexpr std::uint64_t freemem_size  = 1024 * 1024;  // 1 MB
+constexpr std::uint64_t stack_size    = 1024 * 16;    // 16k
+constexpr std::uint64_t stack_start   = 0x0000000040000000;
+constexpr std::uint64_t untrusted_ptr = 0xffffffff80000000;
 #endif
-
-#define DEFAULT_UNTRUSTED_SIZE 8192  // 8 KB
+}  // namespace defaults
+}  // namespace detail
 
 /* parameters for enclave creation */
 namespace Keystone {
 
 class Params {
  public:
-  Params() {
-    simulated      = false;
-    untrusted      = DEFAULT_UNTRUSTED_PTR;
-    untrusted_size = DEFAULT_UNTRUSTED_SIZE;
-    freemem_size   = DEFAULT_FREEMEM_SIZE;
-  }
-
   void setSimulated(bool _simulated) { simulated = _simulated; }
-  void setEnclaveEntry(uint64_t) {
+
+  void setEnclaveEntry(std::uint64_t) {
     printf("WARN: setEnclaveEntry() is deprecated.\n");
   }
-  void setUntrustedMem(uint64_t ptr, uint64_t size) {
+
+  void setUntrustedMem(std::uint64_t ptr, std::uint64_t size) {
     untrusted      = ptr;
     untrusted_size = size;
   }
-  void setFreeMemSize(uint64_t size) { freemem_size = size; }
+
+  void setFreeMemSize(std::uint64_t size) { freemem_size = size; }
   bool isSimulated() { return simulated; }
-  uintptr_t getUntrustedMem() { return untrusted; }
-  uintptr_t getUntrustedSize() { return untrusted_size; }
-  uintptr_t getUntrustedEnd() { return untrusted + untrusted_size; }
-  uintptr_t getFreeMemSize() { return freemem_size; }
+  std::uintptr_t getUntrustedMem() { return untrusted; }
+  std::uintptr_t getUntrustedSize() { return untrusted_size; }
+  std::uintptr_t getUntrustedEnd() { return untrusted + untrusted_size; }
+  std::uintptr_t getFreeMemSize() { return freemem_size; }
 
  private:
-  bool simulated;
-  uint64_t runtime_entry;
-  uint64_t enclave_entry;
-  uint64_t untrusted;
-  uint64_t untrusted_size;
-  uint64_t freemem_size;
+  bool simulated{false};
+  std::uint64_t runtime_entry;
+  std::uint64_t enclave_entry;
+  std::uint64_t untrusted{detail::defaults::untrusted_ptr};
+  std::uint64_t untrusted_size{detail::defaults::untrusted_size};
+  std::uint64_t freemem_size{detail::defaults::freemem_size};
 };
 
 }  // namespace Keystone

--- a/sdk/include/host/Params.hpp
+++ b/sdk/include/host/Params.hpp
@@ -34,23 +34,23 @@ namespace Keystone {
 
 class Params {
  public:
-  void setSimulated(bool _simulated) { simulated = _simulated; }
+  void setSimulated(bool _simulated) noexcept { simulated = _simulated; }
 
   void setEnclaveEntry(std::uint64_t) {
     printf("WARN: setEnclaveEntry() is deprecated.\n");
   }
 
-  void setUntrustedMem(std::uint64_t ptr, std::uint64_t size) {
+  void setUntrustedMem(std::uint64_t ptr, std::uint64_t size) noexcept {
     untrusted      = ptr;
     untrusted_size = size;
   }
 
-  void setFreeMemSize(std::uint64_t size) { freemem_size = size; }
-  bool isSimulated() { return simulated; }
-  std::uintptr_t getUntrustedMem() { return untrusted; }
-  std::uintptr_t getUntrustedSize() { return untrusted_size; }
-  std::uintptr_t getUntrustedEnd() { return untrusted + untrusted_size; }
-  std::uintptr_t getFreeMemSize() { return freemem_size; }
+  void setFreeMemSize(std::uint64_t size) noexcept { freemem_size = size; }
+  bool isSimulated() const noexcept { return simulated; }
+  std::uintptr_t getUntrustedMem() const noexcept { return untrusted; }
+  std::uintptr_t getUntrustedSize() const noexcept { return untrusted_size; }
+  std::uintptr_t getUntrustedEnd() const noexcept { return untrusted + untrusted_size; }
+  std::uintptr_t getFreeMemSize() const noexcept { return freemem_size; }
 
  private:
   bool simulated{false};

--- a/sdk/src/host/ElfFile.cpp
+++ b/sdk/src/host/ElfFile.cpp
@@ -9,7 +9,7 @@
 
 namespace Keystone {
 
-static size_t
+static std::size_t
 fstatFileSize(int filep) {
   int rc;
   struct stat stat_buf;
@@ -73,38 +73,38 @@ ElfFile::initialize(bool _isRuntime) {
 }
 
 /* Functions below are wrappers for libelf */
-size_t
+std::size_t
 ElfFile::getNumProgramHeaders(void) {
   return elf_getNumProgramHeaders(&elf);
 }
 
-size_t
-ElfFile::getProgramHeaderType(size_t ph) {
+std::size_t
+ElfFile::getProgramHeaderType(std::size_t ph) {
   return elf_getProgramHeaderType(&elf, ph);
 }
 
-size_t
-ElfFile::getProgramHeaderFileSize(size_t ph) {
+std::size_t
+ElfFile::getProgramHeaderFileSize(std::size_t ph) {
   return elf_getProgramHeaderFileSize(&elf, ph);
 }
 
-size_t
-ElfFile::getProgramHeaderMemorySize(size_t ph) {
+std::size_t
+ElfFile::getProgramHeaderMemorySize(std::size_t ph) {
   return elf_getProgramHeaderMemorySize(&elf, ph);
 }
 
-uintptr_t
-ElfFile::getProgramHeaderVaddr(size_t ph) {
+std::uintptr_t
+ElfFile::getProgramHeaderVaddr(std::size_t ph) {
   return elf_getProgramHeaderVaddr(&elf, ph);
 }
 
-uintptr_t
+std::uintptr_t
 ElfFile::getEntryPoint() {
   return elf_getEntryPoint(&elf);
 }
 
 void*
-ElfFile::getProgramSegment(size_t ph) {
+ElfFile::getProgramSegment(std::size_t ph) {
   return elf_getProgramSegment(&elf, ph);
 }
 }  // namespace Keystone

--- a/sdk/src/host/ElfFile.cpp
+++ b/sdk/src/host/ElfFile.cpp
@@ -45,7 +45,7 @@ ElfFile::~ElfFile() {
 }
 
 bool
-ElfFile::isValid() {
+ElfFile::isValid() const noexcept {
   return (filep > 0 && fileSize > 0 && ptr != NULL);
 }
 

--- a/sdk/src/host/Enclave.cpp
+++ b/sdk/src/host/Enclave.cpp
@@ -47,8 +47,8 @@ calculate_required_pages(uint64_t eapp_sz, uint64_t rt_sz) {
 
 Error
 Enclave::loadUntrusted() {
-  uintptr_t va_start = ROUND_DOWN(params.getUntrustedMem(), PAGE_BITS);
-  uintptr_t va_end   = ROUND_UP(params.getUntrustedEnd(), PAGE_BITS);
+  std::uintptr_t va_start = ROUND_DOWN(params.getUntrustedMem(), PAGE_BITS);
+  std::uintptr_t va_end   = ROUND_UP(params.getUntrustedEnd(), PAGE_BITS);
 
   while (va_start < va_end) {
     if (!pMemory->allocPage(va_start, 0, UTM_FULL)) {
@@ -61,17 +61,17 @@ Enclave::loadUntrusted() {
 
 /* This function will be deprecated when we implement freemem */
 bool
-Enclave::initStack(uintptr_t start, size_t size, bool is_rt) {
+Enclave::initStack(std::uintptr_t start, std::size_t size, bool is_rt) {
   static char nullpage[PAGE_SIZE] = {
       0,
   };
-  uintptr_t high_addr    = ROUND_UP(start, PAGE_BITS);
-  uintptr_t va_start_stk = ROUND_DOWN((high_addr - size), PAGE_BITS);
+  std::uintptr_t high_addr    = ROUND_UP(start, PAGE_BITS);
+  std::uintptr_t va_start_stk = ROUND_DOWN((high_addr - size), PAGE_BITS);
   int stk_pages          = (high_addr - va_start_stk) / PAGE_SIZE;
 
   for (int i = 0; i < stk_pages; i++) {
     if (!pMemory->allocPage(
-            va_start_stk, (uintptr_t)nullpage,
+            va_start_stk, (std::uintptr_t)nullpage,
             (is_rt ? RT_NOEXEC : USER_NOEXEC)))
       return false;
 
@@ -83,11 +83,11 @@ Enclave::initStack(uintptr_t start, size_t size, bool is_rt) {
 
 bool
 Enclave::mapElf(ElfFile* elf) {
-  uintptr_t va;
+  std::uintptr_t va;
 
   assert(elf);
 
-  size_t num_pages =
+  std::size_t num_pages =
       ROUND_DOWN(elf->getTotalMemorySize(), PAGE_BITS) / PAGE_SIZE;
   va = elf->getMinVaddr();
 
@@ -111,21 +111,21 @@ Enclave::loadElf(ElfFile* elf) {
       continue;
     }
 
-    uintptr_t start      = elf->getProgramHeaderVaddr(i);
-    uintptr_t file_end   = start + elf->getProgramHeaderFileSize(i);
-    uintptr_t memory_end = start + elf->getProgramHeaderMemorySize(i);
+    std::uintptr_t start      = elf->getProgramHeaderVaddr(i);
+    std::uintptr_t file_end   = start + elf->getProgramHeaderFileSize(i);
+    std::uintptr_t memory_end = start + elf->getProgramHeaderMemorySize(i);
     char* src            = reinterpret_cast<char*>(elf->getProgramSegment(i));
-    uintptr_t va         = start;
+    std::uintptr_t va         = start;
 
     /* FIXME: This is a temporary fix for loading iozone binary
      * which has a page-misaligned program header. */
     if (!IS_ALIGNED(va, PAGE_SIZE)) {
-      size_t offset = va - PAGE_DOWN(va);
-      size_t length = PAGE_UP(va) - va;
+      std::size_t offset = va - PAGE_DOWN(va);
+      std::size_t length = PAGE_UP(va) - va;
       char page[PAGE_SIZE];
       memset(page, 0, PAGE_SIZE);
       memcpy(page + offset, (const void*)src, length);
-      if (!pMemory->allocPage(PAGE_DOWN(va), (uintptr_t)page, mode))
+      if (!pMemory->allocPage(PAGE_DOWN(va), (std::uintptr_t)page, mode))
         return Error::PageAllocationFailure;
       va += length;
       src += length;
@@ -133,7 +133,7 @@ Enclave::loadElf(ElfFile* elf) {
 
     /* first load all pages that do not include .bss segment */
     while (va + PAGE_SIZE <= file_end) {
-      if (!pMemory->allocPage(va, (uintptr_t)src, mode))
+      if (!pMemory->allocPage(va, (std::uintptr_t)src, mode))
         return Error::PageAllocationFailure;
 
       src += PAGE_SIZE;
@@ -145,15 +145,15 @@ Enclave::loadElf(ElfFile* elf) {
     if (va < file_end) {
       char page[PAGE_SIZE];
       memset(page, 0, PAGE_SIZE);
-      memcpy(page, (const void*)src, static_cast<size_t>(file_end - va));
-      if (!pMemory->allocPage(va, (uintptr_t)page, mode))
+      memcpy(page, (const void*)src, static_cast<std::size_t>(file_end - va));
+      if (!pMemory->allocPage(va, (std::uintptr_t)page, mode))
         return Error::PageAllocationFailure;
       va += PAGE_SIZE;
     }
 
     /* finally, load the remaining .bss segments */
     while (va < memory_end) {
-      if (!pMemory->allocPage(va, (uintptr_t)nullpage, mode))
+      if (!pMemory->allocPage(va, (std::uintptr_t)nullpage, mode))
         return Error::PageAllocationFailure;
       va += PAGE_SIZE;
     }
@@ -172,8 +172,8 @@ Enclave::validate_and_hash_enclave(struct runtime_params_t args) {
   // hash the runtime parameters
   hash_extend(&hash_ctx, &args, sizeof(struct runtime_params_t));
 
-  uintptr_t runtime_max_seen = 0;
-  uintptr_t user_max_seen    = 0;
+  std::uintptr_t runtime_max_seen = 0;
+  std::uintptr_t user_max_seen    = 0;
 
   // hash the epm contents including the virtual addresses
   int valid = pMemory->validateAndHashEpm(
@@ -226,7 +226,7 @@ Enclave::initFiles(const char* eapppath, const char* runtimepath) {
 }
 
 bool
-Enclave::prepareEnclave(uintptr_t alternatePhysAddr) {
+Enclave::prepareEnclave(std::uintptr_t alternatePhysAddr) {
   // FIXME: this will be deprecated with complete freemem support.
   // We just add freemem size for now.
   uint64_t minPages;
@@ -245,7 +245,7 @@ Enclave::prepareEnclave(uintptr_t alternatePhysAddr) {
   }
 
   /* We switch out the phys addr as needed */
-  uintptr_t physAddr;
+  std::uintptr_t physAddr;
   if (alternatePhysAddr) {
     physAddr = alternatePhysAddr;
   } else {
@@ -258,18 +258,18 @@ Enclave::prepareEnclave(uintptr_t alternatePhysAddr) {
 
 Error
 Enclave::init(const char* eapppath, const char* runtimepath, Params _params) {
-  return this->init(eapppath, runtimepath, _params, (uintptr_t)0);
+  return this->init(eapppath, runtimepath, _params, (std::uintptr_t)0);
 }
 
 const char*
-Enclave::getHash() {
+Enclave::getHash() const noexcept {
   return this->hash;
 }
 
 Error
 Enclave::init(
     const char* eapppath, const char* runtimepath, Params _params,
-    uintptr_t alternatePhysAddr) {
+    std::uintptr_t alternatePhysAddr) {
   params = _params;
 
   if (params.isSimulated()) {
@@ -329,7 +329,7 @@ Enclave::init(
   }
 #endif /* USE_FREEMEM */
 
-  uintptr_t utm_free;
+  std::uintptr_t utm_free;
   utm_free = pMemory->allocUtm(params.getUntrustedSize());
 
   if (!utm_free) {
@@ -344,13 +344,13 @@ Enclave::init(
 
   struct runtime_params_t runtimeParams;
   runtimeParams.runtime_entry =
-      reinterpret_cast<uintptr_t>(runtimeFile->getEntryPoint());
+      reinterpret_cast<std::uintptr_t>(runtimeFile->getEntryPoint());
   runtimeParams.user_entry =
-      reinterpret_cast<uintptr_t>(enclaveFile->getEntryPoint());
+      reinterpret_cast<std::uintptr_t>(enclaveFile->getEntryPoint());
   runtimeParams.untrusted_ptr =
-      reinterpret_cast<uintptr_t>(params.getUntrustedMem());
+      reinterpret_cast<std::uintptr_t>(params.getUntrustedMem());
   runtimeParams.untrusted_size =
-      reinterpret_cast<uintptr_t>(params.getUntrustedSize());
+      reinterpret_cast<std::uintptr_t>(params.getUntrustedSize());
 
   pMemory->startFreeMem();
 
@@ -383,7 +383,7 @@ Enclave::init(
 }
 
 bool
-Enclave::mapUntrusted(size_t size) {
+Enclave::mapUntrusted(std::size_t size) {
   if (size == 0) {
     return true;
   }
@@ -415,7 +415,7 @@ Enclave::destroy() {
 }
 
 Error
-Enclave::run(uintptr_t* retval) {
+Enclave::run(std::uintptr_t* retval) {
   if (params.isSimulated()) {
     return Error::Success;
   }
@@ -439,12 +439,12 @@ Enclave::run(uintptr_t* retval) {
 }
 
 void*
-Enclave::getSharedBuffer() {
+Enclave::getSharedBuffer() noexcept {
   return shared_buffer;
 }
 
-size_t
-Enclave::getSharedBufferSize() {
+std::size_t
+Enclave::getSharedBufferSize() const noexcept {
   return shared_buffer_size;
 }
 

--- a/sdk/src/host/KeystoneDevice.cpp
+++ b/sdk/src/host/KeystoneDevice.cpp
@@ -7,10 +7,8 @@
 
 namespace Keystone {
 
-KeystoneDevice::KeystoneDevice() { eid = -1; }
-
 Error
-KeystoneDevice::create(uint64_t minPages) {
+KeystoneDevice::create(std::uint64_t minPages) {
   struct keystone_ioctl_create_enclave encl;
   encl.min_pages = minPages;
 
@@ -26,8 +24,8 @@ KeystoneDevice::create(uint64_t minPages) {
   return Error::Success;
 }
 
-uintptr_t
-KeystoneDevice::initUTM(size_t size) {
+std::uintptr_t
+KeystoneDevice::initUTM(std::size_t size) {
   struct keystone_ioctl_create_enclave encl;
   encl.eid                   = eid;
   encl.params.untrusted_size = size;
@@ -40,7 +38,7 @@ KeystoneDevice::initUTM(size_t size) {
 
 Error
 KeystoneDevice::finalize(
-    uintptr_t runtimePhysAddr, uintptr_t eappPhysAddr, uintptr_t freePhysAddr,
+    std::uintptr_t runtimePhysAddr, std::uintptr_t eappPhysAddr, std::uintptr_t freePhysAddr,
     struct runtime_params_t params) {
   struct keystone_ioctl_create_enclave encl;
   encl.eid           = eid;
@@ -75,12 +73,12 @@ KeystoneDevice::destroy() {
 }
 
 Error
-KeystoneDevice::__run(bool resume, uintptr_t* ret) {
+KeystoneDevice::__run(bool resume, std::uintptr_t* ret) {
   struct keystone_ioctl_run_enclave encl;
   encl.eid = eid;
 
   Error error;
-  uint64_t request;
+  std::uint64_t request;
 
   if (resume) {
     error   = Error::IoctlErrorResume;
@@ -113,17 +111,17 @@ KeystoneDevice::__run(bool resume, uintptr_t* ret) {
 }
 
 Error
-KeystoneDevice::run(uintptr_t* ret) {
+KeystoneDevice::run(std::uintptr_t* ret) {
   return __run(false, ret);
 }
 
 Error
-KeystoneDevice::resume(uintptr_t* ret) {
+KeystoneDevice::resume(std::uintptr_t* ret) {
   return __run(true, ret);
 }
 
 void*
-KeystoneDevice::map(uintptr_t addr, size_t size) {
+KeystoneDevice::map(std::uintptr_t addr, std::size_t size) {
   assert(fd >= 0);
   void* ret;
   ret = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, addr);
@@ -143,19 +141,19 @@ KeystoneDevice::initDevice(Params params) {
 }
 
 Error
-MockKeystoneDevice::create(uint64_t minPages) {
+MockKeystoneDevice::create(std::uint64_t minPages) {
   eid = -1;
   return Error::Success;
 }
 
-uintptr_t
-MockKeystoneDevice::initUTM(size_t size) {
+std::uintptr_t
+MockKeystoneDevice::initUTM(std::size_t size) {
   return 0;
 }
 
 Error
 MockKeystoneDevice::finalize(
-    uintptr_t runtimePhysAddr, uintptr_t eappPhysAddr, uintptr_t freePhysAddr,
+    std::uintptr_t runtimePhysAddr, std::uintptr_t eappPhysAddr, std::uintptr_t freePhysAddr,
     struct runtime_params_t params) {
   return Error::Success;
 }
@@ -166,12 +164,12 @@ MockKeystoneDevice::destroy() {
 }
 
 Error
-MockKeystoneDevice::run(uintptr_t* ret) {
+MockKeystoneDevice::run(std::uintptr_t* ret) {
   return Error::Success;
 }
 
 Error
-MockKeystoneDevice::resume(uintptr_t* ret) {
+MockKeystoneDevice::resume(std::uintptr_t* ret) {
   return Error::Success;
 }
 
@@ -181,7 +179,7 @@ MockKeystoneDevice::initDevice(Params params) {
 }
 
 void*
-MockKeystoneDevice::map(uintptr_t addr, size_t size) {
+MockKeystoneDevice::map(std::uintptr_t addr, std::size_t size) {
   sharedBuffer = malloc(size);
   return sharedBuffer;
 }


### PR DESCRIPTION
These changes are minimal and include:
- Marking members functions as ``const``/``noexcept`` if appropriate. 
- Using the standard types from ``<cstdint>`` (and prepending all such types with ``std::``). 
- Removing constructors that just initialized member variables. Instead, we initialize them where they are declared. 
- Replacing some constants expressed as macros with equivalent (type safe) ``constexpr`` values.

No code logic has been modified. 