### PR TITLE
Fix off-by-one in the driver

### DIFF
--- a/linux-keystone-driver/keystone-page.c
+++ b/linux-keystone-driver/keystone-page.c
@@ -40,7 +40,7 @@ int epm_init(struct epm* epm, unsigned int min_pages)
   count = 0x1 << order;
 
   /* prevent kernel from complaining about an invalid argument */
-  if (order <= MAX_ORDER)
+  if (order < MAX_ORDER)
     epm_vaddr = (vaddr_t) __get_free_pages(GFP_HIGHUSER, order);
 
 #ifdef CONFIG_CMA


### PR DESCRIPTION
The existing driver code checks whether an enclave's requested size is less than or equal to some `MAX_ORDER` defined in the Linux kernel, and chooses the kernel allocator to use based on this. However, this should be a strict less than check instead. If we attempt to instantiate an enclave of size exactly `MAX_ORDER`, we will trigger a bug condition in Linux's `page_alloc.c` in the `__alloc_pages` function on line 5406. This condition is enforced when the requested order is greater than or equal to `MAX_ORDER`. This PR changes the driver such that we do not attempt to use the wrong allocator and no longer see these bug messages.