### PR TITLE
Use base location of runtime source files, not compiled location

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -42,6 +42,10 @@ rt_option(ENV_SETUP "Set up stack environments like glibc expects" OFF)
 rt_option(INTERNAL_STRACE "Debug syscalls" OFF)
 rt_option(DEBUG "Enable debugging" OFF)
 
+if(DEFINED EYRIE_SRCDIR)
+    add_compile_options(-fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=${EYRIE_SRCDIR})
+endif()
+
 include_directories($ENV{KEYSTONE_SDK_DIR}/include/edge)
 include_directories(tmplib)
 include_directories(include)


### PR DESCRIPTION
When debugging in GDB, it can be helpful to use tools such as `layout src` in order to use the source files for a specific runtime. However, the embedded debugging information points to the copied source directory in the build directory rather than the canonical source under `runtime/`. This PR adds a compile flag, `-fdebug-prefix-map`, which embeds debugging information that points to the canonical runtime source. This is useful in exotic (but seen!) debugging configurations where the runtime build directory may have moved or no longer exists.