### PR TITLE
Fix memory allocation in the runtime

### DIFF
--- a/runtime/call/linux_wrap.c
+++ b/runtime/call/linux_wrap.c
@@ -170,11 +170,17 @@ uintptr_t syscall_brk(void* addr){
   uintptr_t req_break = (uintptr_t)addr;
 
   uintptr_t current_break = get_program_break();
-  uintptr_t ret = current_break;
+  uintptr_t ret;
   int req_page_count = 0;
 
   // Return current break if null or current break
-  if( req_break == 0  || req_break <= current_break){
+  if (req_break == 0) {
+    ret = current_break;
+    goto done;
+  }
+
+  if(req_break <= current_break){
+    ret = req_break;
     goto done;
   }
 
@@ -196,7 +202,7 @@ uintptr_t syscall_brk(void* addr){
   }
 
   // Success
-  set_program_break(req_break);
+  set_program_break(PAGE_UP(req_break));
   ret = req_break;
 
 

--- a/runtime/mm/mm.c
+++ b/runtime/mm/mm.c
@@ -87,7 +87,7 @@ alloc_page(uintptr_t vpn, int flags)
   }
 
 	/* otherwise, allocate one from the freemem */
-  page = spa_get();
+  page = spa_get_zero();
   assert(page);
 
   *pte = pte_create(ppn(__pa(page)), flags | PTE_V);


### PR DESCRIPTION
This PR bundles two bugfixes to Eyrie's memory allocation system. The first is a fix to the `brk` syscall which is used to allocate memory. Often, calls to `brk` will use page aligned addresses as arguments -- but not always. The existing functionality in `brk` specifically runs into problems in the `brk` call *after* such a non-page-aligned call. For example, if we initially have `current_break = 0x2040000000`:

`brk(0x2040000B48)`: `req_page_count = 1`. In this case, we allocate one page at VPN `0x2040000`.
`brk(0x0000002040021B48)`: `req_page_count = 33`. Since we earlier set `current_break = 0x2040000B48`, we will accidentally *reallocate* VPN `0x2040000` and thus not allocate one page at the end of this requested break. This will result in segfaults on address `0x2040021388`, for example.

The second fix to the `alloc_page` function, which now zeroes pages that it allocates. I observed issues with some libcs (musl, specifically) which assume (in the heap implementation) that pages returned from the runtime are zeroed. Since this wasn't the case, some really cursed memory corruptions were observed. This does come at a performance overhead, but I believe that zeroing allocated pages is a pretty standard choice in OS's.