### PR TITLE
Fix some syscalls

### DIFF
--- a/runtime/call/io_wrap.c
+++ b/runtime/call/io_wrap.c
@@ -124,7 +124,7 @@ uintptr_t io_syscall_read(int fd, void* buf, size_t len){
   copy_to_user(buf, args->buf, ret > len? len: ret);
 
  done:
-  print_strace("[runtime] proxied read (size: %lu) = %li\r\n",len, ret);
+  print_strace("[runtime] proxied read from %i (size: %lu) = %li\r\n",fd, len, ret);
   return ret;
 }
 
@@ -160,7 +160,7 @@ uintptr_t io_syscall_write(int fd, void* buf, size_t len){
   ret = dispatch_edgecall_syscall(edge_syscall, totalsize);
 
  done:
-  print_strace("[runtime] proxied write (size: %lu) = %li\r\n",len, ret);
+  print_strace("[runtime] proxied write to %i (size: %lu) = %li\r\n",fd, len, ret);
   return ret;
 }
 

--- a/runtime/call/net_wrap.c
+++ b/runtime/call/net_wrap.c
@@ -280,6 +280,9 @@ uintptr_t io_syscall_getsockname(int sockfd, uintptr_t addr,
   size_t totalsize = (sizeof(struct edge_syscall)) + sizeof(sargs_SYS_getsockname);
   ret = dispatch_edgecall_syscall(edge_syscall, totalsize);
 
+  copy_to_user((void *) addr, &args->addr, args->addrlen);
+  copy_to_user((void *) addrlen, &args->addrlen, sizeof(socklen_t));
+
   print_strace("[runtime] proxied getsockname: fd: %d, ret: %d\r\n", args->sockfd, ret);
   return ret;
 }


### PR DESCRIPTION
This PR just adds some more information to the strace for read/write, indicating what file descriptor is being operated on. Additionally, it fixes the `getsockname` syscall which was not previously returning its results back to the eapp.