### PR TITLE
[Documentation] Fix `How-to-Debug.rst`

### DIFF
--- a/docs/source/Getting-Started/How-to-Debug.rst
+++ b/docs/source/Getting-Started/How-to-Debug.rst
@@ -11,15 +11,15 @@ First compile with debugging symbols
 
 .. code-block:: bash
 
-# in your <build directory>
-cmake -DCMAKE_BUILD_TYPE=Debug ..
+    # in your <build directory>
+    cmake -DCMAKE_BUILD_TYPE=Debug ..
 
 
 From your `build` directory where you ran `make`, use:
 
 .. code-block:: bash
 
-./scripts/run-qemu.sh -debug
+    ./scripts/run-qemu.sh -debug
 
 
 All cores will immediately hang at the first instruction (i.e., bootrom), waiting for `gdb` to be attached.
@@ -32,23 +32,23 @@ For example, if you want to debug with the `bbl` symbols
 
 .. code-block:: bash
 
-# in your <build directory>
-riscv64-unknown-linux-gnu-gdb ./sm.build/platform/generic/firmware/fw_payload.elf
+    # in your <build directory>
+    riscv64-unknown-linux-gnu-gdb ./sm.build/platform/generic/firmware/fw_payload.elf
 
 
 If you want to debug with the kernel's debug information
 
 .. code-block:: bash
 
-# in your <build directory>
-riscv64-unknown-linux-gnu-gdb ./linux.build/vmlinux
+    # in your <build directory>
+    riscv64-unknown-linux-gnu-gdb ./linux.build/vmlinux
 
 
 Then, attach to QEMU on the port printed by the starting qemu script:
 
 .. code-block:: bash
 
-(gdb) target remote localhost:$PORT
+    (gdb) target remote localhost:$PORT
 
 
 Now, you can start debugging the SM (bbl) or the kernel.
@@ -58,7 +58,7 @@ Before setting breakpoints, you should run following command:
 
 .. code-block:: bash
 
-(gdb) set riscv use-compressed-breakpoints no
+    (gdb) set riscv use-compressed-breakpoints no
 
 
 To see why we need that command, see [this issue](https://github.com/riscv/riscv-binutils-gdb/issues/106)
@@ -74,5 +74,5 @@ For example,
 
 .. code-block:: bash
 
-./riscv-qemu/riscv64-softmmu/qemu-system-riscv64 -d in_asm -D debug.log #...etc...
+    ./riscv-qemu/riscv64-softmmu/qemu-system-riscv64 -d in_asm -D debug.log #...etc...
 


### PR DESCRIPTION
Code-blocks are not showing up correctly because of the indentation