### PR TITLE
[Documentation] Update QEMU dependencies

### DIFF
--- a/docs/source/Getting-Started/Install-Dependencies.rst
+++ b/docs/source/Getting-Started/Install-Dependencies.rst
@@ -12,9 +12,9 @@ Ubuntu
   sudo apt install autoconf automake autotools-dev bc \
   bison build-essential curl expat libexpat1-dev flex gawk gcc git \
   gperf libgmp-dev libmpc-dev libmpfr-dev libtool texinfo tmux \
-  patchutils zlib1g-dev wget bzip2 patch vim-common lbzip2 python \
+  patchutils zlib1g-dev wget bzip2 patch vim-common lbzip2 python3 \
   pkg-config libglib2.0-dev libpixman-1-dev libssl-dev screen \
-  device-tree-compiler expect makeself unzip cpio rsync cmake p7zip-full
+  device-tree-compiler expect makeself unzip cpio rsync cmake ninja-build p7zip-full
 
 .. note::
   You need Git version >= 2.11.0 to use ``./fast-setup.sh``, because the script uses
@@ -28,4 +28,3 @@ In order to use the Rust version of the security monitor (only available for 0.X
   rustup +nightly component add rust-src
   rustup +nightly target add riscv64gc-unknown-none-elf
   cargo +nightly install cargo-xbuild
-


### PR DESCRIPTION
## Proposed Changes
- Update `[python](https://packages.debian.org/de/buster/python)` to `[python3](https://packages.debian.org/bullseye/python3)`, as the former will not be found on recent apt versions.
- Add the dependency on `ninja-build`, which is declared in the [dockerfiles](https://github.com/keystone-enclave/keystone/blob/a85df47debff262034d97d078c38b646243b4aeb/docker/Dockerfile#LL12C65-L12C72) but not in the documentation.

Closes #332 