### PR TITLE
[Page fault] critical mmap issue: missing TLB flush causing page faults

### DIFF
--- a/runtime/call/linux_wrap.c
+++ b/runtime/call/linux_wrap.c
@@ -104,6 +104,7 @@ uintptr_t syscall_munmap(void *addr, size_t length){
 
   free_pages(vpn((uintptr_t)addr), length/RISCV_PAGE_SIZE);
   ret = 0;
+  tlb_flush();
   return ret;
 }
 
@@ -155,6 +156,7 @@ uintptr_t syscall_mmap(void *addr, size_t length, int prot, int flags,
   }
 
  done:
+  tlb_flush();
   print_strace("[runtime] [mmap]: addr: 0x%p, length %lu, prot 0x%x, flags 0x%x, fd %i, offset %lu (%li pages %x) = 0x%p\r\n", addr, length, prot, flags, fd, offset, req_pages, pte_flags, ret);
 
   // If we get here everything went wrong
@@ -207,6 +209,7 @@ uintptr_t syscall_brk(void* addr){
 
 
  done:
+  tlb_flush();
   print_strace("[runtime] brk (0x%p) (req pages %i) = 0x%p\r\n",req_break, req_page_count, ret);
   return ret;
 


### PR DESCRIPTION
There was a critical bug in mmap-related syscalls that are not flushing TLB after page table update.

```
[runtime] page fault at 0x317ba6 on 0x10 (scause: 0xd)
```