### PR TITLE
Allow example apps to be built outside of Keystone build dir

### DIFF
--- a/sdk/examples/CMakeLists.txt
+++ b/sdk/examples/CMakeLists.txt
@@ -30,9 +30,6 @@ set(KEYSTONE_LIB_EDGE ${KEYSTONE_SDK_DIR}/lib/libkeystone-edge.a)
 set(KEYSTONE_LIB_VERIFIER ${KEYSTONE_SDK_DIR}/lib/libkeystone-verifier.a)
 set(KEYSTONE_LIB_EAPP ${KEYSTONE_SDK_DIR}/lib/libkeystone-eapp.a)
 
-# find program "makeself"
-find_program(MAKESELF makeself)
-
 # create a phony target "examples"
 add_custom_target("examples")
 

--- a/sdk/macros.cmake
+++ b/sdk/macros.cmake
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 include(ExternalProject)
 
+# find program "makeself"
+find_program(MAKESELF makeself)
+
 macro(global_set Name Value)
     #  message("set ${Name} to " ${ARGN})
     set(${Name} "${Value}" CACHE STRING "NoDesc" FORCE)
@@ -105,12 +108,14 @@ macro(add_eyrie_runtime target_name plugins) # the files are passed via ${ARGN}
   list(APPEND PLUGIN_FLAGS "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}")
   list(APPEND PLUGIN_FLAGS "-DCMAKE_OBJCOPY=${CMAKE_OBJCOPY}")
 
-  get_runtime_dir(EYRIE_SRCDIR)
+  if(NOT DEFINED KEYSTONE_EYRIE_RUNTIME)
+    get_runtime_dir(KEYSTONE_EYRIE_RUNTIME)
+  endif()
 
   ExternalProject_Add(eyrie-${target_name}
     PREFIX ${runtime_prefix}
-    DOWNLOAD_COMMAND rm -rf ${eyrie_src} && cp -ar ${EYRIE_SRCDIR} ${eyrie_src}
-    CMAKE_ARGS "${PLUGIN_FLAGS}" -DEYRIE_SRCDIR=${EYRIE_SRCDIR}
+    DOWNLOAD_COMMAND rm -rf ${eyrie_src} && cp -ar ${KEYSTONE_EYRIE_RUNTIME} ${eyrie_src}
+    CMAKE_ARGS "${PLUGIN_FLAGS}" -DEYRIE_SRCDIR=${KEYSTONE_EYRIE_RUNTIME}
     BUILD_IN_SOURCE TRUE
     BUILD_BYPRODUCTS ${eyrie_src}/eyrie-rt ${eyrie_src}/.options_log
     INSTALL_COMMAND "")


### PR DESCRIPTION
We need to be able to build Keystone example apps outside of the main build tree.
This unblocks VMWare Certifier Keystone example app.