### PR TITLE
Checking that offset is strictly smaller than shared_len

### DIFF
--- a/sdk/src/edge/edge_call.c
+++ b/sdk/src/edge/edge_call.c
@@ -22,7 +22,7 @@ edge_call_get_ptr_from_offset(
   // TODO double check these checks
 
   /* Validate that _shared_start+offset is sane */
-  if (offset > UINTPTR_MAX - _shared_start || offset > _shared_len) {
+  if (offset > UINTPTR_MAX - _shared_start || offset >= _shared_len) {
     return -1;
   }
 


### PR DESCRIPTION
While this is guaranteed to not happen for data_len > 0, it might turn out beneficial in case return value is used with a different data_len.