### PR TITLE
Fix bss section corruption bug.

### DIFF
--- a/sdk/src/host/Enclave.cpp
+++ b/sdk/src/host/Enclave.cpp
@@ -121,7 +121,7 @@ Enclave::loadElf(ElfFile* elf) {
      * which has a page-misaligned program header. */
     if (!IS_ALIGNED(va, PAGE_SIZE)) {
       size_t offset = va - PAGE_DOWN(va);
-      size_t length = PAGE_UP(va) - va;
+      size_t length = std::min(file_end, PAGE_UP(va)) - va;
       char page[PAGE_SIZE];
       memset(page, 0, PAGE_SIZE);
       memcpy(page + offset, (const void*)src, length);


### PR DESCRIPTION
If a LOAD segment which contains data and bss section is not page-aligned and the bss section is located in the first page of the segment, the bss section could be corrupted with values other than zero and that would cause program invariants to be broken leading to unexpected behavior. This PR is to fix this issue.