### PR TITLE
Explicitly depend on keystone-runtime from keystone-examples

### DIFF
--- a/overlays/keystone/package/keystone-examples/keystone-examples.mk
+++ b/overlays/keystone/package/keystone-examples/keystone-examples.mk
@@ -10,7 +10,7 @@ else
 include $(KEYSTONE)/mkutils/pkg-keystone.mk
 endif
 
-KEYSTONE_EXAMPLES_DEPENDENCIES += host-keystone-sdk
+KEYSTONE_EXAMPLES_DEPENDENCIES += host-keystone-sdk keystone-runtime
 KEYSTONE_EXAMPLES_CONF_OPTS += -DKEYSTONE_SDK_DIR=$(HOST_DIR)/usr/share/keystone/sdk \
                                 -DKEYSTONE_EYRIE_RUNTIME=$(KEYSTONE_RUNTIME_BUILDDIR)
 KEYSTONE_EXAMPLES_MAKE_ENV += KEYSTONE_SDK_DIR=$(HOST_DIR)/usr/share/keystone/sdk


### PR DESCRIPTION
We've received some reports of `keystone-examples` builds not correctly copying the `keystone-runtime` sources (thank you @asyarifstudio). This patch adds an explicit Makefile dependency from `keystone-examples` to `keystone-runtime`, although Buildroot should be picking this up through the `Config.in` dependency also.