### PR TITLE
driver: Remove orphaned fields

### DIFF
--- a/linux-keystone-driver/keystone_user.h
+++ b/linux-keystone-driver/keystone_user.h
@@ -44,9 +44,6 @@ struct keystone_ioctl_create_enclave {
   uintptr_t min_pages;
 
   // virtual addresses
-  uintptr_t runtime_vaddr;
-  uintptr_t user_vaddr;
-
   uintptr_t pt_ptr;
   uintptr_t utm_free_ptr;
 

--- a/sdk/include/host/keystone_user.h
+++ b/sdk/include/host/keystone_user.h
@@ -44,9 +44,6 @@ struct keystone_ioctl_create_enclave {
   uintptr_t min_pages;
 
   // virtual addresses
-  uintptr_t runtime_vaddr;
-  uintptr_t user_vaddr;
-
   uintptr_t pt_ptr;
   uintptr_t utm_free_ptr;
 


### PR DESCRIPTION
"user_vaddr" and "runtime_vaddr" in struct keystone_ioctl_enclave have no use. They are neither used by the SDK nor the driver. Remove them.