### PR TITLE
Replace fork URL artifact with upstream in CVA6_INSTALL.md

### DIFF
--- a/CVA6_INSTALL.md
+++ b/CVA6_INSTALL.md
@@ -4,7 +4,6 @@
 ```bash
 git clone https://github.com/keystone-enclave/keystone.git
 cd keystone
-git checkout dev-cva6-support
 ./fast-setup.sh
 ```
 

--- a/CVA6_INSTALL.md
+++ b/CVA6_INSTALL.md
@@ -2,7 +2,7 @@
 ### Setup
 
 ```bash
-git clone https://github.com/andreaskuster/keystone.git
+git clone https://github.com/keystone-enclave/keystone.git
 cd keystone
 git checkout dev-cva6-support
 ./fast-setup.sh


### PR DESCRIPTION
Through debugging of issue #374 , we found a URL artifact still pointing to the pre-upstream repo in the install instructions. This PR replaces the old URL with the upstream counterpart.