### PR TITLE
Add build-generic64/ dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 riscv/
 riscv64/
 riscv32/
+build-generic64/


### PR DESCRIPTION
I'm guessing everyone else is using Docker, but maybe because I'm building manually, my output is to this directory. Afaik this is the default build directory?