### PR TITLE
Add jq as a dependency in docs

### DIFF
--- a/docs/source/Getting-Started/QEMU-Install-Dependencies.rst
+++ b/docs/source/Getting-Started/QEMU-Install-Dependencies.rst
@@ -12,7 +12,7 @@ Install the following packages.
 
   sudo apt update
   sudo apt install autoconf automake autotools-dev bc \
-  bison build-essential curl expat libexpat1-dev flex gawk gcc git \
+  bison build-essential curl expat jq libexpat1-dev flex gawk gcc git \
   gperf libgmp-dev libmpc-dev libmpfr-dev libtool texinfo tmux \
   patchutils zlib1g-dev wget bzip2 patch vim-common lbzip2 python3 \
   pkg-config libglib2.0-dev libpixman-1-dev libssl-dev screen \


### PR DESCRIPTION
This little utility [is used for `linux-configure`](https://github.com/keystone-enclave/keystone/blob/master/Makefile#L107), and wasn't included as a part of my desktop version of Ubuntu.

Maybe this should be included in your Dockerfile? I'm not using the image so someone should check if it's there or not.