### PR TITLE
Move communication structs / defines into shared headers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,33 +195,7 @@ jobs:
         run: |
           sudo apt-get -y update && sudo apt-get -y install ccache
 
-      # First, fetch the caches themselves. We need both the base cache that
-      # was used as well as the overlay caches. Note that the base caches may
-      # fail, which is okay.
-      - name: Restore buildroot packages
-        uses: actions/cache/restore@v3
-        with:
-          path: dl.tar
-          key: ${{ needs.build.outputs.buildroot-dl-matched-key }}
-
-      - name: Restore ccache
-        uses: actions/cache/restore@v3
-        with:
-          path: ccache.tar.xz
-          key: ${{ needs.build.outputs.ccache-matched-key }}
-
-      - name: Prepare output directories
-        run: |
-          rm -rf buildroot/dl buildroot-ccache
-          mkdir -p buildroot/dl/ buildroot-ccache/
-          if [[ -f dl.tar ]]; then
-            tar -xf dl.tar -C buildroot
-          fi
-
-          if [[ -f ccache.tar.xz ]]; then
-            tar -xf ccache.tar.xz
-          fi
-
+      # Fetch new cache changes from this workflow run, if any
       - name: Fetch updated buildroot packages
         uses: actions/download-artifact@v4
         with:
@@ -232,7 +206,6 @@ jobs:
         with:
           pattern: keystone-*-ccache
 
-      # Then, combine the caches
       - name: Check which caches to update
         id: check-caches
         run: |
@@ -254,6 +227,32 @@ jobs:
             # Merge ccache directories
             echo "BUILDROOT_CCACHE_UPDATE=true" >> "$GITHUB_OUTPUT"
             touch .update-ccache
+          fi
+
+      - name: Restore buildroot packages
+        uses: actions/cache/restore@v3
+        if: ${{ steps.check-caches.outputs.BUILDROOT_DL_UPDATE == 'true' }}
+        with:
+          path: dl.tar
+          key: ${{ needs.build.outputs.buildroot-dl-matched-key }}
+
+      - name: Restore ccache
+        uses: actions/cache/restore@v3
+        if: ${{ steps.check-caches.outputs.BUILDROOT_CCACHE_UPDATE == 'true' }}
+        with:
+          path: ccache.tar.xz
+          key: ${{ needs.build.outputs.ccache-matched-key }}
+
+      - name: Prepare output directories
+        run: |
+          rm -rf buildroot/dl buildroot-ccache
+          mkdir -p buildroot/dl/ buildroot-ccache/
+          if [[ -f dl.tar ]]; then
+            tar -xf dl.tar -C buildroot
+          fi
+
+          if [[ -f ccache.tar.xz ]]; then
+            tar -xf ccache.tar.xz
           fi
 
       - name: Merge caches

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -327,7 +327,7 @@ jobs:
     - name: Checkout Keystone
       uses: actions/checkout@v3
       with:
-        submodules: 'recursive'
+        submodules: 'true'
 
     - name: Run ctest
       run: |

--- a/.github/workflows/test-system.yml
+++ b/.github/workflows/test-system.yml
@@ -38,7 +38,7 @@ jobs:
         screen -L -dmS qemu bash -c "make run 2>&1 | tee run.log"
 
         # TODO: check for connectivity instead of sleeping
-        sleep 20
+        sleep 60
 
         export CALL_LOGFILE=cmd.log
         echo "" > $CALL_LOGFILE

--- a/linux-keystone-driver/Makefile
+++ b/linux-keystone-driver/Makefile
@@ -8,6 +8,12 @@ ifneq ($(KERNELRELEASE),)
 		keystone-enclave.o \
 	  keystone-sbi.o
 	obj-m += keystone-driver.o
+
+ifeq ($(KEYSTONE_SDK_DIR),)
+    $(error KEYSTONE_SDK_DIR not defined)
+endif
+
+	ccflags-y := -I$(KEYSTONE_SDK_DIR)/include/shared
 else
 
 PWD := $(shell pwd)

--- a/linux-keystone-driver/keystone-sbi.c
+++ b/linux-keystone-driver/keystone-sbi.c
@@ -1,25 +1,25 @@
 #include "keystone-sbi.h"
 
 struct sbiret sbi_sm_create_enclave(struct keystone_sbi_create_t* args) {
-  return sbi_ecall(KEYSTONE_SBI_EXT_ID,
+  return sbi_ecall(SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE,
       SBI_SM_CREATE_ENCLAVE,
       (unsigned long) args, 0, 0, 0, 0, 0);
 }
 
 struct sbiret sbi_sm_run_enclave(unsigned long eid) {
-  return sbi_ecall(KEYSTONE_SBI_EXT_ID,
+  return sbi_ecall(SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE,
       SBI_SM_RUN_ENCLAVE,
       eid, 0, 0, 0, 0, 0);
 }
 
 struct sbiret sbi_sm_destroy_enclave(unsigned long eid) {
-  return sbi_ecall(KEYSTONE_SBI_EXT_ID,
+  return sbi_ecall(SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE,
       SBI_SM_DESTROY_ENCLAVE,
       eid, 0, 0, 0, 0, 0);
 }
 
 struct sbiret sbi_sm_resume_enclave(unsigned long eid) {
-  return sbi_ecall(KEYSTONE_SBI_EXT_ID,
+  return sbi_ecall(SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE,
       SBI_SM_RESUME_ENCLAVE,
       eid, 0, 0, 0, 0, 0);
 }

--- a/linux-keystone-driver/keystone-sbi.h
+++ b/linux-keystone-driver/keystone-sbi.h
@@ -6,35 +6,9 @@
 #define _KEYSTONE_SBI_
 
 #include "keystone_user.h"
+#include "sm_call.h"
+
 #include <asm/sbi.h>
-
-#define KEYSTONE_SBI_EXT_ID     0x08424b45
-#define SBI_SM_CREATE_ENCLAVE   2001
-#define SBI_SM_DESTROY_ENCLAVE  2002
-#define SBI_SM_RUN_ENCLAVE      2003
-#define SBI_SM_RESUME_ENCLAVE   2005
-
-
-struct keystone_sbi_pregion_t
-{
-  uintptr_t paddr;
-  size_t size;
-};
-
-struct keystone_sbi_create_t
-{
-  // Memory regions for the enclave
-  struct keystone_sbi_pregion_t epm_region;
-  struct keystone_sbi_pregion_t utm_region;
-
-  // physical addresses
-  uintptr_t runtime_paddr;
-  uintptr_t user_paddr;
-  uintptr_t free_paddr;
-
-  // Parameters
-  struct runtime_params_t params;
-};
 
 struct sbiret sbi_sm_create_enclave(struct keystone_sbi_create_t* args);
 struct sbiret sbi_sm_destroy_enclave(unsigned long eid);

--- a/overlays/keystone/boot/keystone-sm/Config.in
+++ b/overlays/keystone/boot/keystone-sm/Config.in
@@ -1,6 +1,7 @@
 config BR2_TARGET_KEYSTONE_SM
         bool "Keystone security monitor"
-	select BR2_TARGET_OPENSBI
+        select BR2_TARGET_OPENSBI
+        depends on BR2_PACKAGE_HOST_KEYSTONE_SDK
         help
           Keystone security monitor augmentations
           to OpenSBI

--- a/overlays/keystone/boot/keystone-sm/keystone-sm.mk
+++ b/overlays/keystone/boot/keystone-sm/keystone-sm.mk
@@ -10,9 +10,12 @@ else
 include $(KEYSTONE)/mkutils/pkg-keystone.mk
 endif
 
-# Make OpenSBI depend on this build
-OPENSBI_DEPENDENCIES += keystone-sm
-$(OPENSBI_TARGET_CONFIGURE): keystone-sm-install
+# Make OpenSBI depend on this build, which depends on the SDK since it contains
+# the shared headers which specify the communication protocol between the host
+# <> kernel <> sm <> runtime <> eapp
+
+OPENSBI_DEPENDENCIES += keystone-sm host-keystone-sdk
+$(OPENSBI_TARGET_CONFIGURE): keystone-sm-install host-keystone-sdk-install
 
 # Point OpenSBI at the correct location of the SM sources
 OPENSBI_MAKE_ENV += PLATFORM_DIR=$(KEYSTONE_SM_BUILDDIR)/plat/

--- a/overlays/keystone/package/keystone-driver/Config.in
+++ b/overlays/keystone/package/keystone-driver/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KEYSTONE_DRIVER
         bool "Keystone driver"
+        depends on BR2_PACKAGE_HOST_KEYSTONE_SDK
         help
           Linux driver for the Keystone TEE system

--- a/overlays/keystone/package/keystone-driver/keystone-driver.mk
+++ b/overlays/keystone/package/keystone-driver/keystone-driver.mk
@@ -10,6 +10,8 @@ else
 include $(KEYSTONE)/mkutils/pkg-keystone.mk
 endif
 
+KEYSTONE_DRIVER_DEPENDENCIES += host-keystone-sdk
+
 $(eval $(keystone-package))
 $(eval $(kernel-module))
 $(eval $(generic-package))

--- a/overlays/keystone/package/keystone-runtime/Config.in
+++ b/overlays/keystone/package/keystone-runtime/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_KEYSTONE_RUNTIME
         bool "Keystone Eyrie runtime"
+        depends on BR2_PACKAGE_HOST_KEYSTONE_SDK
         help
           Eyrie runtime

--- a/overlays/keystone/package/keystone-sdk/keystone-sdk.mk
+++ b/overlays/keystone/package/keystone-sdk/keystone-sdk.mk
@@ -10,13 +10,17 @@ else
 include $(KEYSTONE)/mkutils/pkg-keystone.mk
 endif
 
-HOST_KEYSTONE_SDK_CONF_OPTS += -DKEYSTONE_SDK_DIR=$(HOST_DIR)/usr/share/keystone/sdk \
-                                 -DKEYSTONE_BITS=${KEYSTONE_BITS}
+# Export the variable below for any other keystone packages to use
+export KEYSTONE_SDK_DIR=$(HOST_DIR)/usr/share/keystone/sdk
 
+HOST_KEYSTONE_SDK_CONF_OPTS += -DKEYSTONE_SDK_DIR=$(KEYSTONE_SDK_DIR) \
+                                 -DKEYSTONE_BITS=${KEYSTONE_BITS}
 HOST_KEYSTONE_SDK_DEPENDENCIES += toolchain
 
-# Clean the examples too if we clean this package
-host-keystone-sdk-dirclean: keystone-examples-dirclean
+# Clean dependant packages if we clean this one
+host-keystone-sdk-dirclean: keystone-examples-dirclean \
+                                keystone-sm-dirclean \
+                                keystone-driver-dirclean
 
 $(eval $(host-keystone-package))
 $(eval $(host-cmake-package))

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -46,6 +46,7 @@ if(DEFINED EYRIE_SRCDIR)
 endif()
 
 include_directories(${KEYSTONE_SDK_DIR}/include/edge)
+include_directories(${KEYSTONE_SDK_DIR}/include/shared)
 include_directories(tmplib)
 include_directories(include)
 

--- a/runtime/call/sbi.c
+++ b/runtime/call/sbi.c
@@ -2,8 +2,6 @@
 
 #include "mm/vm_defs.h"
 
-#define SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE 0x08424b45
-
 #define SBI_CALL(___ext, ___which, ___arg0, ___arg1, ___arg2)    \
   ({                                                             \
     register uintptr_t a0 __asm__("a0") = (uintptr_t)(___arg0);  \

--- a/runtime/call/syscall.c
+++ b/runtime/call/syscall.c
@@ -43,7 +43,7 @@ uintptr_t dispatch_edgecall_syscall(struct edge_syscall* syscall_data_ptr, size_
     return -1;
   }
 
-  ret = sbi_stop_enclave(1);
+  ret = sbi_stop_enclave(STOP_EDGE_CALL_HOST);
 
   if (ret != 0) {
     return -1;
@@ -92,7 +92,7 @@ uintptr_t dispatch_edgecall_ocall( unsigned long call_id,
     goto ocall_error;
   }
 
-  ret = sbi_stop_enclave(1);
+  ret = sbi_stop_enclave(STOP_EDGE_CALL_HOST);
 
   if (ret != 0) {
     goto ocall_error;

--- a/runtime/include/call/sbi.h
+++ b/runtime/include/call/sbi.h
@@ -8,25 +8,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#define SBI_SET_TIMER 0
-#define SBI_CONSOLE_PUTCHAR 1
-#define SBI_CONSOLE_GETCHAR 2
-
-#define SBI_SM_CREATE_ENCLAVE    2001
-#define SBI_SM_DESTROY_ENCLAVE   2002
-#define SBI_SM_RUN_ENCLAVE       2003
-#define SBI_SM_RESUME_ENCLAVE    2005
-#define SBI_SM_RANDOM            3001
-#define SBI_SM_ATTEST_ENCLAVE    3002
-#define SBI_SM_GET_SEALING_KEY   3003
-#define SBI_SM_STOP_ENCLAVE      3004
-#define SBI_SM_EXIT_ENCLAVE      3006
-#define SBI_SM_CALL_PLUGIN       4000
-
-/* Plugin IDs and Call IDs */
-#define SM_MULTIMEM_PLUGIN_ID   0x01
-#define SM_MULTIMEM_CALL_GET_SIZE 0x01
-#define SM_MULTIMEM_CALL_GET_ADDR 0x02
+#include "sm_call.h"
 
 void
 sbi_putchar(char c);

--- a/runtime/include/call/syscall.h
+++ b/runtime/include/call/syscall.h
@@ -10,12 +10,7 @@
 #include "edge_syscall.h"
 #include "mm/vm.h"
 
-#define RUNTIME_SYSCALL_UNKNOWN             1000
-#define RUNTIME_SYSCALL_OCALL               1001
-#define RUNTIME_SYSCALL_SHAREDCOPY          1002
-#define RUNTIME_SYSCALL_ATTEST_ENCLAVE      1003
-#define RUNTIME_SYSCALL_GET_SEALING_KEY     1004
-#define RUNTIME_SYSCALL_EXIT                1101
+#include "eyrie_call.h"
 
 void handle_syscall(struct encl_ctx* ctx);
 void init_edge_internals(void);

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -9,6 +9,7 @@ include(AddCMockaTest)
 enable_testing()
 
 include_directories(../include)
+include_directories(../../sdk/include/shared/)
 
 add_cmocka_test(test_string SOURCES string.c COMPILE_OPTIONS -I${CMAKE_BINARY_DIR}/cmocka/include LINK_LIBRARIES cmocka)
 add_cmocka_test(test_merkle

--- a/scripts/ci/build-keystone.sh
+++ b/scripts/ci/build-keystone.sh
@@ -42,7 +42,7 @@ mount -t overlay overlay \
 	-o lowerdir="$CCACHE_LOWER",upperdir="$CCACHE_UPPER",workdir="$CCACHE_WORK" \
 	"$PWD/buildroot-ccache"
 
-BUILDROOT_CCACHE="$PWD/buildroot-ccache" make -j$(nproc)
+BUILDROOT_CCACHE="$PWD/buildroot-ccache" make -j$(( 2 * $(nproc) ))
 
 EOF
 

--- a/scripts/ci/build-runtime.sh
+++ b/scripts/ci/build-runtime.sh
@@ -33,4 +33,4 @@ cmake "$@" \
 	../runtime
 
 # Build
-make -j$(nproc)
+make -j$(( 2 * $(nproc) ))

--- a/sdk/include/app/syscall.h
+++ b/sdk/include/app/syscall.h
@@ -8,13 +8,8 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "sealing.h"
-/* TODO We should be syncing these more explictly with the runtime
-   defs */
-#define SYSCALL_OCALL 1001
-#define SYSCALL_SHAREDCOPY 1002
-#define SYSCALL_ATTEST_ENCLAVE 1003
-#define SYSCALL_GET_SEALING_KEY 1004
-#define SYSCALL_EXIT 1101
+
+#include "shared/eyrie_call.h"
 
 #define SYSCALL(which, arg0, arg1, arg2, arg3, arg4)           \
   ({                                                           \

--- a/sdk/include/host/ElfFile.hpp
+++ b/sdk/include/host/ElfFile.hpp
@@ -6,10 +6,12 @@
 
 #include <fcntl.h>
 #include <unistd.h>
+
 #include <iostream>
 #include <string>
+
 #include "./common.h"
-#include "./keystone_user.h"
+#include "shared/keystone_user.h"
 
 extern "C" {
 #include "./elf.h"

--- a/sdk/include/host/KeystoneDevice.hpp
+++ b/sdk/include/host/KeystoneDevice.hpp
@@ -11,13 +11,15 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #include <cerrno>
 #include <cstring>
 #include <iostream>
+
 #include "./common.h"
-#include "./keystone_user.h"
 #include "Error.hpp"
 #include "Params.hpp"
+#include "shared/keystone_user.h"
 
 namespace Keystone {
 
@@ -40,7 +42,7 @@ class KeystoneDevice {
   virtual uintptr_t initUTM(size_t size);
   virtual Error finalize(
       uintptr_t runtimePhysAddr, uintptr_t eappPhysAddr, uintptr_t freePhysAddr,
-      struct runtime_params_t params);
+      struct runtime_va_params_t params);
   virtual Error destroy();
   virtual Error run(uintptr_t* ret);
   virtual Error resume(uintptr_t* ret);
@@ -60,7 +62,7 @@ class MockKeystoneDevice : public KeystoneDevice {
   uintptr_t initUTM(size_t size);
   Error finalize(
       uintptr_t runtimePhysAddr, uintptr_t eappPhysAddr, uintptr_t freePhysAddr,
-      struct runtime_params_t params);
+      struct runtime_va_params_t params);
   Error destroy();
   Error run(uintptr_t* ret);
   Error resume(uintptr_t* ret);

--- a/sdk/include/host/common.h
+++ b/sdk/include/host/common.h
@@ -1,6 +1,8 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
+#include "shared/sm_err.h"
+
 #define RT_NOEXEC 0
 #define USER_NOEXEC 1
 #define RT_FULL 2
@@ -24,11 +26,5 @@
 #define ERROR(str, ...) fprintf(stderr, MSG(str) "\n", ##__VA_ARGS__)
 #define PERROR(str) perror(MSG(str))
 #define IS_ALIGNED(x, align) (!((x) & (align - 1)))
-
-/* Currently we have only one command avaiable from the enclave.
- * We need to move it out to other header file (e.g., keystone-sm.h) */
-#define KEYSTONE_ENCLAVE_DONE 0
-#define KEYSTONE_ENCLAVE_INTERRUPTED 100002
-#define KEYSTONE_ENCLAVE_EDGE_CALL_HOST 100011
 
 #endif

--- a/sdk/include/host/keystone_user.h
+++ b/sdk/include/host/keystone_user.h
@@ -7,6 +7,9 @@
 
 #include <linux/ioctl.h>
 #include <linux/types.h>
+
+#include "sm_call.h"
+
 // Linux generic TEE subsystem magic defined in <linux/tee.h>
 #define KEYSTONE_IOC_MAGIC 0xa4
 
@@ -29,13 +32,6 @@
 #define RT_FULL 2
 #define USER_FULL 3
 #define UTM_FULL 4
-
-struct runtime_params_t {
-  uintptr_t runtime_entry;
-  uintptr_t user_entry;
-  uintptr_t untrusted_ptr;
-  uintptr_t untrusted_size;
-};
 
 struct keystone_ioctl_create_enclave {
   uintptr_t eid;
@@ -61,7 +57,7 @@ struct keystone_ioctl_create_enclave {
   uintptr_t utm_size;
 
   // Runtime Parameters
-  struct runtime_params_t params;
+  struct runtime_va_params_t params;
 };
 
 struct keystone_ioctl_run_enclave {

--- a/sdk/include/shared/eyrie_call.h
+++ b/sdk/include/shared/eyrie_call.h
@@ -1,0 +1,11 @@
+#ifndef __EYRIE_CALL_H__
+#define __EYRIE_CALL_H__
+
+#define RUNTIME_SYSCALL_UNKNOWN             1000
+#define RUNTIME_SYSCALL_OCALL               1001
+#define RUNTIME_SYSCALL_SHAREDCOPY          1002
+#define RUNTIME_SYSCALL_ATTEST_ENCLAVE      1003
+#define RUNTIME_SYSCALL_GET_SEALING_KEY     1004
+#define RUNTIME_SYSCALL_EXIT                1101
+
+#endif  // __EYRIE_CALL_H__

--- a/sdk/include/shared/keystone_user.h
+++ b/sdk/include/shared/keystone_user.h
@@ -5,10 +5,13 @@
 #ifndef _KEYSTONE_USER_H_
 #define _KEYSTONE_USER_H_
 
-#include <linux/types.h>
 #include <linux/ioctl.h>
+#include <linux/types.h>
+
+#include "sm_call.h"
+
 // Linux generic TEE subsystem magic defined in <linux/tee.h>
-#define KEYSTONE_IOC_MAGIC  0xa4
+#define KEYSTONE_IOC_MAGIC 0xa4
 
 // ioctl definition
 #define KEYSTONE_IOC_CREATE_ENCLAVE \
@@ -30,17 +33,10 @@
 #define USER_FULL 3
 #define UTM_FULL 4
 
-struct runtime_params_t {
-  uintptr_t runtime_entry;
-  uintptr_t user_entry;
-  uintptr_t untrusted_ptr;
-  uintptr_t  untrusted_size;
-};
-
 struct keystone_ioctl_create_enclave {
   uintptr_t eid;
 
-  //Min pages required
+  // Min pages required
   uintptr_t min_pages;
 
   // virtual addresses
@@ -50,7 +46,7 @@ struct keystone_ioctl_create_enclave {
   uintptr_t pt_ptr;
   uintptr_t utm_free_ptr;
 
-  //Used for hash
+  // Used for hash
   uintptr_t epm_paddr;
   uintptr_t utm_paddr;
   uintptr_t runtime_paddr;
@@ -61,7 +57,7 @@ struct keystone_ioctl_create_enclave {
   uintptr_t utm_size;
 
   // Runtime Parameters
-  struct runtime_params_t params;
+  struct runtime_va_params_t params;
 };
 
 struct keystone_ioctl_run_enclave {

--- a/sdk/include/shared/sm_call.h
+++ b/sdk/include/shared/sm_call.h
@@ -1,0 +1,74 @@
+#ifndef __SM_CALL_H__
+#define __SM_CALL_H__
+
+// BKE (Berkeley Keystone Enclave)
+#define SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE 0x08424b45
+
+#define SBI_SET_TIMER 0
+#define SBI_CONSOLE_PUTCHAR 1
+#define SBI_CONSOLE_GETCHAR 2
+
+/* 0-1999 are not used (deprecated) */
+#define FID_RANGE_DEPRECATED      1999
+/* 2000-2999 are called by host */
+#define SBI_SM_CREATE_ENCLAVE    2001
+#define SBI_SM_DESTROY_ENCLAVE   2002
+#define SBI_SM_RUN_ENCLAVE       2003
+#define SBI_SM_RESUME_ENCLAVE    2005
+#define FID_RANGE_HOST           2999
+
+/* 3000-3999 are called by enclave */
+#define SBI_SM_RANDOM            3001
+#define SBI_SM_ATTEST_ENCLAVE    3002
+#define SBI_SM_GET_SEALING_KEY   3003
+#define SBI_SM_STOP_ENCLAVE      3004
+#define SBI_SM_EXIT_ENCLAVE      3006
+#define FID_RANGE_ENCLAVE        3999
+
+/* 4000-4999 are experimental */
+#define SBI_SM_CALL_PLUGIN        4000
+#define FID_RANGE_CUSTOM          4999
+
+/* Plugin IDs and Call IDs */
+#define SM_MULTIMEM_PLUGIN_ID   0x01
+#define SM_MULTIMEM_CALL_GET_SIZE 0x01
+#define SM_MULTIMEM_CALL_GET_ADDR 0x02
+
+/* Enclave stop reasons requested */
+#define STOP_TIMER_INTERRUPT  0
+#define STOP_EDGE_CALL_HOST   1
+#define STOP_EXIT_ENCLAVE     2
+
+/* Structs for interfacing into the SM */
+struct runtime_va_params_t {
+  uintptr_t runtime_entry;
+  uintptr_t user_entry;
+  uintptr_t untrusted_ptr;
+  uintptr_t untrusted_size;
+};
+
+struct runtime_pa_params_t {
+  uintptr_t dram_base;
+  uintptr_t dram_size;
+  uintptr_t runtime_base;
+  uintptr_t user_base;
+  uintptr_t free_base;
+};
+
+struct keystone_sbi_pregion_t {
+  uintptr_t paddr;
+  size_t size;
+};
+
+struct keystone_sbi_create_t {
+  struct keystone_sbi_pregion_t epm_region;
+  struct keystone_sbi_pregion_t utm_region;
+
+  uintptr_t runtime_paddr;
+  uintptr_t user_paddr;
+  uintptr_t free_paddr;
+
+  struct runtime_va_params_t params;
+};
+
+#endif  // __SM_CALL_H__

--- a/sdk/include/shared/sm_err.h
+++ b/sdk/include/shared/sm_err.h
@@ -1,0 +1,34 @@
+#ifndef __SM_ERR_H__
+#define __SM_ERR_H__
+
+#define SBI_ERR_SM_ENCLAVE_SUCCESS                     0
+#define SBI_ERR_SM_ENCLAVE_UNKNOWN_ERROR               100000
+#define SBI_ERR_SM_ENCLAVE_INVALID_ID                  100001
+#define SBI_ERR_SM_ENCLAVE_INTERRUPTED                 100002
+#define SBI_ERR_SM_ENCLAVE_PMP_FAILURE                 100003
+#define SBI_ERR_SM_ENCLAVE_NOT_RUNNABLE                100004
+#define SBI_ERR_SM_ENCLAVE_NOT_DESTROYABLE             100005
+#define SBI_ERR_SM_ENCLAVE_REGION_OVERLAPS             100006
+#define SBI_ERR_SM_ENCLAVE_NOT_ACCESSIBLE              100007
+#define SBI_ERR_SM_ENCLAVE_ILLEGAL_ARGUMENT            100008
+#define SBI_ERR_SM_ENCLAVE_NOT_RUNNING                 100009
+#define SBI_ERR_SM_ENCLAVE_NOT_RESUMABLE               100010
+#define SBI_ERR_SM_ENCLAVE_EDGE_CALL_HOST              100011
+#define SBI_ERR_SM_ENCLAVE_NOT_INITIALIZED             100012
+#define SBI_ERR_SM_ENCLAVE_NO_FREE_RESOURCE            100013
+#define SBI_ERR_SM_ENCLAVE_SBI_PROHIBITED              100014
+#define SBI_ERR_SM_ENCLAVE_ILLEGAL_PTE                 100015
+#define SBI_ERR_SM_ENCLAVE_NOT_FRESH                   100016
+#define SBI_ERR_SM_DEPRECATED                          100099
+#define SBI_ERR_SM_NOT_IMPLEMENTED                     100100
+
+#define SBI_ERR_SM_PMP_SUCCESS                         0
+#define SBI_ERR_SM_PMP_REGION_SIZE_INVALID             100020
+#define SBI_ERR_SM_PMP_REGION_NOT_PAGE_GRANULARITY     100021
+#define SBI_ERR_SM_PMP_REGION_NOT_ALIGNED              100022
+#define SBI_ERR_SM_PMP_REGION_MAX_REACHED              100023
+#define SBI_ERR_SM_PMP_REGION_INVALID                  100024
+#define SBI_ERR_SM_PMP_REGION_OVERLAP                  100025
+#define SBI_ERR_SM_PMP_REGION_IMPOSSIBLE_TOR           100026
+
+#endif  // __SM_ERR_H__

--- a/sdk/src/CMakeLists.txt
+++ b/sdk/src/CMakeLists.txt
@@ -14,5 +14,5 @@ endforeach()
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/common
   DESTINATION ${out_dir}/include)
-
-
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/shared
+  DESTINATION ${out_dir}/include)

--- a/sdk/src/app/syscall.c
+++ b/sdk/src/app/syscall.c
@@ -10,18 +10,18 @@ int
 ocall(
     unsigned long call_id, void* data, size_t data_len, void* return_buffer,
     size_t return_len) {
-  return SYSCALL_5(
-      SYSCALL_OCALL, call_id, data, data_len, return_buffer, return_len);
+  return SYSCALL_5(RUNTIME_SYSCALL_OCALL,
+      call_id, data, data_len, return_buffer, return_len);
 }
 
 int
 copy_from_shared(void* dst, uintptr_t offset, size_t data_len) {
-  return SYSCALL_3(SYSCALL_SHAREDCOPY, dst, offset, data_len);
+  return SYSCALL_3(RUNTIME_SYSCALL_SHAREDCOPY, dst, offset, data_len);
 }
 
 int
 attest_enclave(void* report, void* data, size_t size) {
-  return SYSCALL_3(SYSCALL_ATTEST_ENCLAVE, report, data, size);
+  return SYSCALL_3(RUNTIME_SYSCALL_ATTEST_ENCLAVE, report, data, size);
 }
 
 /* returns sealing key */
@@ -29,7 +29,7 @@ int
 get_sealing_key(
     struct sealing_key* sealing_key_struct, size_t sealing_key_struct_size,
     void* key_ident, size_t key_ident_size) {
-  return SYSCALL_4(
-      SYSCALL_GET_SEALING_KEY, sealing_key_struct, sealing_key_struct_size,
+  return SYSCALL_4(RUNTIME_SYSCALL_GET_SEALING_KEY,
+      sealing_key_struct, sealing_key_struct_size,
       key_ident, key_ident_size);
 }

--- a/sdk/src/host/Enclave.cpp
+++ b/sdk/src/host/Enclave.cpp
@@ -7,8 +7,8 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 extern "C" {
-#include "./keystone_user.h"
 #include "common/sha3.h"
+#include "shared/keystone_user.h"
 }
 #include "ElfFile.hpp"
 #include "hash_util.hpp"
@@ -203,7 +203,7 @@ Enclave::init(
 
   pMemory->startFreeMem();
 
-  struct runtime_params_t runtimeParams;
+  struct runtime_va_params_t runtimeParams;
   runtimeParams.untrusted_ptr =
       reinterpret_cast<uintptr_t>(utm_free);
   runtimeParams.untrusted_size =

--- a/sdk/src/host/KeystoneDevice.cpp
+++ b/sdk/src/host/KeystoneDevice.cpp
@@ -41,7 +41,7 @@ KeystoneDevice::initUTM(size_t size) {
 Error
 KeystoneDevice::finalize(
     uintptr_t runtimePhysAddr, uintptr_t eappPhysAddr, uintptr_t freePhysAddr,
-    struct runtime_params_t params) {
+    struct runtime_va_params_t params) {
   struct keystone_ioctl_create_enclave encl;
   encl.eid           = eid;
   encl.runtime_paddr = runtimePhysAddr;
@@ -95,11 +95,11 @@ KeystoneDevice::__run(bool resume, uintptr_t* ret) {
   }
 
   switch (encl.error) {
-    case KEYSTONE_ENCLAVE_EDGE_CALL_HOST:
+    case SBI_ERR_SM_ENCLAVE_EDGE_CALL_HOST:
       return Error::EdgeCallHost;
-    case KEYSTONE_ENCLAVE_INTERRUPTED:
+    case SBI_ERR_SM_ENCLAVE_INTERRUPTED:
       return Error::EnclaveInterrupted;
-    case KEYSTONE_ENCLAVE_DONE:
+    case SBI_ERR_SM_ENCLAVE_SUCCESS:
       if (ret) {
         *ret = encl.value;
       }
@@ -156,7 +156,7 @@ MockKeystoneDevice::initUTM(size_t size) {
 Error
 MockKeystoneDevice::finalize(
     uintptr_t runtimePhysAddr, uintptr_t eappPhysAddr, uintptr_t freePhysAddr,
-    struct runtime_params_t params) {
+    struct runtime_va_params_t params) {
   return Error::Success;
 }
 

--- a/sdk/src/host/Memory.cpp
+++ b/sdk/src/host/Memory.cpp
@@ -3,8 +3,10 @@
 // All Rights Reserved. See LICENSE for license details.
 //------------------------------------------------------------------------------
 #include "Memory.hpp"
-#include <keystone_user.h>
+
 #include <sys/stat.h>
+
+#include "shared/keystone_user.h"
 
 namespace Keystone {
 

--- a/sm/plat/fpga/ariane/config.mk
+++ b/sm/plat/fpga/ariane/config.mk
@@ -4,4 +4,9 @@ ifeq ($(KEYSTONE_SM),)
 $(error KEYSTONE_SM not defined for SM)
 endif
 
-platform-cflags-y = -I$(KEYSTONE_SM)/src -I$(src_dir)/platform/$(PLATFORM)/include
+ifeq ($(KEYSTONE_SDK_DIR),)
+$(error KEYSTONE_SDK_DIR not defined)
+endif
+
+platform-cflags-y = -I$(KEYSTONE_SM)/src -I$(src_dir)/platform/$(PLATFORM)/include \
+                        -I$(KEYSTONE_SDK_DIR)/include/shared

--- a/sm/plat/generic/config.mk
+++ b/sm/plat/generic/config.mk
@@ -6,4 +6,9 @@ ifeq ($(KEYSTONE_SM),)
 $(error KEYSTONE_SM not defined for SM)
 endif
 
-platform-cflags-y = -I$(KEYSTONE_SM)/src -I$(src_dir)/platform/$(PLATFORM)/include
+ifeq ($(KEYSTONE_SDK_DIR),)
+$(error KEYSTONE_SDK_DIR not defined)
+endif
+
+platform-cflags-y = -I$(KEYSTONE_SM)/src -I$(src_dir)/platform/$(PLATFORM)/include \
+                        -I$(KEYSTONE_SDK_DIR)/include/shared

--- a/sm/src/enclave.c
+++ b/sm/src/enclave.c
@@ -238,9 +238,9 @@ uintptr_t get_enclave_region_base(enclave_id eid, int memid)
  * Does NOT do verification of dest, assumes caller knows what that is.
  * Dest should be inside the SM memory.
  */
-unsigned long copy_enclave_create_args(uintptr_t src, struct keystone_sbi_create* dest){
+unsigned long copy_enclave_create_args(uintptr_t src, struct keystone_sbi_create_t* dest){
 
-  int region_overlap = copy_to_sm(dest, src, sizeof(struct keystone_sbi_create));
+  int region_overlap = copy_to_sm(dest, src, sizeof(struct keystone_sbi_create_t));
 
   if (region_overlap)
     return SBI_ERR_SM_ENCLAVE_REGION_OVERLAPS;
@@ -272,7 +272,7 @@ static unsigned long copy_enclave_report(struct enclave* enclave,
     return SBI_ERR_SM_ENCLAVE_SUCCESS;
 }
 
-static int is_create_args_valid(struct keystone_sbi_create* args)
+static int is_create_args_valid(struct keystone_sbi_create_t* args)
 {
   uintptr_t epm_start, epm_end;
 
@@ -334,7 +334,7 @@ static int is_create_args_valid(struct keystone_sbi_create* args)
  *
  * This may fail if: it cannot allocate PMP regions, EIDs, etc
  */
-unsigned long create_enclave(unsigned long *eidptr, struct keystone_sbi_create create_args)
+unsigned long create_enclave(unsigned long *eidptr, struct keystone_sbi_create_t create_args)
 {
   /* EPM and UTM parameters */
   uintptr_t base = create_args.epm_region.paddr;
@@ -352,7 +352,7 @@ unsigned long create_enclave(unsigned long *eidptr, struct keystone_sbi_create c
 
   /* set va params */
   struct runtime_va_params_t params = create_args.params;
-  struct runtime_pa_params pa_params;
+  struct runtime_pa_params_t pa_params;
   pa_params.dram_base = base;
   pa_params.dram_size = size;
   pa_params.runtime_base = create_args.runtime_paddr;
@@ -493,7 +493,7 @@ unsigned long destroy_enclave(enclave_id eid)
   enclaves[eid].encl_satp = 0;
   enclaves[eid].n_thread = 0;
   enclaves[eid].params = (struct runtime_va_params_t) {0};
-  enclaves[eid].pa_params = (struct runtime_pa_params) {0};
+  enclaves[eid].pa_params = (struct runtime_pa_params_t) {0};
   for(i=0; i < ENCLAVE_REGIONS_MAX; i++){
     enclaves[eid].regions[i].type = REGION_INVALID;
   }

--- a/sm/src/enclave.h
+++ b/sm/src/enclave.h
@@ -31,11 +31,6 @@ typedef enum {
   RUNNING,
 } enclave_state;
 
-/* Enclave stop reasons requested */
-#define STOP_TIMER_INTERRUPT  0
-#define STOP_EDGE_CALL_HOST   1
-#define STOP_EXIT_ENCLAVE     2
-
 /* For now, eid's are a simple unsigned int */
 typedef unsigned int enclave_id;
 
@@ -75,7 +70,7 @@ struct enclave
 
   /* parameters */
   struct runtime_va_params_t params;
-  struct runtime_pa_params pa_params;
+  struct runtime_pa_params_t pa_params;
 
   /* enclave execution context */
   unsigned int n_thread;
@@ -115,7 +110,7 @@ struct sealing_key
 
 /*** SBI functions & external functions ***/
 // callables from the host
-unsigned long create_enclave(unsigned long *eid, struct keystone_sbi_create create_args);
+unsigned long create_enclave(unsigned long *eid, struct keystone_sbi_create_t create_args);
 unsigned long destroy_enclave(enclave_id eid);
 unsigned long run_enclave(struct sbi_trap_regs *regs, enclave_id eid);
 unsigned long resume_enclave(struct sbi_trap_regs *regs, enclave_id eid);
@@ -127,7 +122,7 @@ unsigned long attest_enclave(uintptr_t report, uintptr_t data, uintptr_t size, e
 unsigned long validate_and_hash_enclave(struct enclave* enclave);
 // TODO: These functions are supposed to be internal functions.
 void enclave_init_metadata();
-unsigned long copy_enclave_create_args(uintptr_t src, struct keystone_sbi_create* dest);
+unsigned long copy_enclave_create_args(uintptr_t src, struct keystone_sbi_create_t* dest);
 int get_enclave_region_index(enclave_id eid, enum enclave_region_type type);
 uintptr_t get_enclave_region_base(enclave_id eid, int memid);
 uintptr_t get_enclave_region_size(enclave_id eid, int memid);

--- a/sm/src/sm-sbi-opensbi.h
+++ b/sm/src/sm-sbi-opensbi.h
@@ -6,9 +6,12 @@
 #include "sbi/sbi_error.h"
 #include "sbi/sbi_scratch.h"
 #include <sbi/sbi_ecall.h>
+
+#include "sm_call.h"
+
 /* Inbound interfaces */
 extern struct sbi_ecall_extension ecall_keystone_enclave;
-#define SBI_EXT_EXPERIMENTAL_KEYSTONE_ENCLAVE 0x08424b45 // BKE (Berkeley Keystone Enclave)
+
 //int sbi_sm_interface(struct sbi_scratch *scratch, unsigned long extension_id,
 //                     struct sbi_trap_regs  *regs,
 //                     unsigned long *out_val,

--- a/sm/src/sm-sbi.c
+++ b/sm/src/sm-sbi.c
@@ -14,7 +14,7 @@
 
 unsigned long sbi_sm_create_enclave(unsigned long* eid, uintptr_t create_args)
 {
-  struct keystone_sbi_create create_args_local;
+  struct keystone_sbi_create_t create_args_local;
   unsigned long ret;
 
   ret = copy_enclave_create_args(create_args, &create_args_local);

--- a/sm/src/sm.h
+++ b/sm/src/sm.h
@@ -13,55 +13,8 @@
 #define SMM_BASE  0x80000000
 #define SMM_SIZE  0x200000
 
-/* 0-1999 are not used (deprecated) */
-#define FID_RANGE_DEPRECATED      1999
-/* 2000-2999 are called by host */
-#define SBI_SM_CREATE_ENCLAVE     2001
-#define SBI_SM_DESTROY_ENCLAVE    2002
-#define SBI_SM_RUN_ENCLAVE        2003
-#define SBI_SM_RESUME_ENCLAVE     2005
-#define FID_RANGE_HOST            2999
-/* 3000-3999 are called by enclave */
-#define SBI_SM_RANDOM             3001
-#define SBI_SM_ATTEST_ENCLAVE     3002
-#define SBI_SM_GET_SEALING_KEY    3003
-#define SBI_SM_STOP_ENCLAVE       3004
-#define SBI_SM_EXIT_ENCLAVE       3006
-#define FID_RANGE_ENCLAVE         3999
-/* 4000-4999 are experimental */
-#define SBI_SM_CALL_PLUGIN        4000
-#define FID_RANGE_CUSTOM          4999
-
-/* error codes */
-#define SBI_ERR_SM_ENCLAVE_SUCCESS                     0
-#define SBI_ERR_SM_ENCLAVE_UNKNOWN_ERROR               100000
-#define SBI_ERR_SM_ENCLAVE_INVALID_ID                  100001
-#define SBI_ERR_SM_ENCLAVE_INTERRUPTED                 100002
-#define SBI_ERR_SM_ENCLAVE_PMP_FAILURE                 100003
-#define SBI_ERR_SM_ENCLAVE_NOT_RUNNABLE                100004
-#define SBI_ERR_SM_ENCLAVE_NOT_DESTROYABLE             100005
-#define SBI_ERR_SM_ENCLAVE_REGION_OVERLAPS             100006
-#define SBI_ERR_SM_ENCLAVE_NOT_ACCESSIBLE              100007
-#define SBI_ERR_SM_ENCLAVE_ILLEGAL_ARGUMENT            100008
-#define SBI_ERR_SM_ENCLAVE_NOT_RUNNING                 100009
-#define SBI_ERR_SM_ENCLAVE_NOT_RESUMABLE               100010
-#define SBI_ERR_SM_ENCLAVE_EDGE_CALL_HOST              100011
-#define SBI_ERR_SM_ENCLAVE_NOT_INITIALIZED             100012
-#define SBI_ERR_SM_ENCLAVE_NO_FREE_RESOURCE            100013
-#define SBI_ERR_SM_ENCLAVE_SBI_PROHIBITED              100014
-#define SBI_ERR_SM_ENCLAVE_ILLEGAL_PTE                 100015
-#define SBI_ERR_SM_ENCLAVE_NOT_FRESH                   100016
-#define SBI_ERR_SM_DEPRECATED                          100099
-#define SBI_ERR_SM_NOT_IMPLEMENTED                     100100
-
-#define SBI_ERR_SM_PMP_SUCCESS                         0
-#define SBI_ERR_SM_PMP_REGION_SIZE_INVALID             100020
-#define SBI_ERR_SM_PMP_REGION_NOT_PAGE_GRANULARITY     100021
-#define SBI_ERR_SM_PMP_REGION_NOT_ALIGNED              100022
-#define SBI_ERR_SM_PMP_REGION_MAX_REACHED              100023
-#define SBI_ERR_SM_PMP_REGION_INVALID                  100024
-#define SBI_ERR_SM_PMP_REGION_OVERLAP                  100025
-#define SBI_ERR_SM_PMP_REGION_IMPOSSIBLE_TOR           100026
+#include "sm_call.h"
+#include "sm_err.h"
 
 void sm_init(bool cold_boot);
 
@@ -73,42 +26,6 @@ int sm_derive_sealing_key(unsigned char *key,
                           const unsigned char *key_ident,
                           size_t key_ident_size,
                           const unsigned char *enclave_hash);
-
-/* creation parameters */
-struct keystone_sbi_pregion
-{
-  uintptr_t paddr;
-  size_t size;
-};
-struct runtime_va_params_t
-{
-  uintptr_t runtime_entry;
-  uintptr_t user_entry;
-  uintptr_t untrusted_ptr;
-  uintptr_t untrusted_size;
-};
-
-struct runtime_pa_params
-{
-  uintptr_t dram_base;
-  uintptr_t dram_size;
-  uintptr_t runtime_base;
-  uintptr_t user_base;
-  uintptr_t free_base;
-};
-
-struct keystone_sbi_create
-{
-  struct keystone_sbi_pregion epm_region;
-  struct keystone_sbi_pregion utm_region;
-
-  uintptr_t runtime_paddr;
-  uintptr_t user_paddr;
-  uintptr_t free_paddr;
-
-  struct runtime_va_params_t params;
-  unsigned int* eid_pptr; // TODO: remove?
-};
 
 int osm_pmp_set(uint8_t perm);
 #endif


### PR DESCRIPTION
This PR consolidates duplicated definitions of various structs, enums, and defines which are used for inter-project communication. This includes mainly the SDK <-> driver <-> SM <-> runtime <-> eapp interfaces.