### PR TITLE
keystone-driver: linux 6.8 support

### DIFF
--- a/linux-keystone-driver/keystone-page.c
+++ b/linux-keystone-driver/keystone-page.c
@@ -6,6 +6,7 @@
 #include <linux/kernel.h>
 #include "keystone.h"
 #include <linux/dma-mapping.h>
+#include <linux/version.h>
 
 /* Destroy all memory associated with an EPM */
 int epm_destroy(struct epm* epm) {
@@ -40,7 +41,11 @@ int epm_init(struct epm* epm, unsigned int min_pages)
   count = 0x1 << order;
 
   /* prevent kernel from complaining about an invalid argument */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+  if (order < MAX_PAGE_ORDER)
+#else
   if (order < MAX_ORDER)
+#endif
     epm_vaddr = (vaddr_t) __get_free_pages(GFP_HIGHUSER, order);
 
 #ifdef CONFIG_CMA


### PR DESCRIPTION
This PR adds support for newest stable linux to keystone driver.

In Linux 6.8, macro `MAX_ORDER` is renamed to `MAX_PAGE_ORDER`.
https://elixir.bootlin.com/linux/v6.8.8/source/include/linux/mmzone.h#L30

Compilation will fail in linux 6.8 because of this change. 
To avoid this, I added preprocessor that changes the name depending on the kernel version.

This works correctly under Ubuntu 24.04 that uses kernel `6.8.0-31-generic`.
I also tested on real hardware, HiFive Unmatched.

Thanks. 