### PR TITLE
Fix a heading in Remote-Attestation.rst

### DIFF
--- a/docs/source/Getting-Started/Tutorials/Remote-Attestation.rst
+++ b/docs/source/Getting-Started/Tutorials/Remote-Attestation.rst
@@ -132,7 +132,7 @@ The main job of the host is to relay messages from the remote verifier
 to the EApp, and vice-versa.
 
 Remote Verifier: verifier.cpp
-=============================
+-----------------------------
 
 The remote verifier is the most interesting part of this tutorial. As
 mentioned above, although the remote verifier is actually implemented


### PR DESCRIPTION
"Remote Verifier: verifier.cpp" should be part of the remote attestation tutorial. But due to incorrect heading this is currently being split into a new tutorial at https://docs.keystone-enclave.org/en/latest/Getting-Started/Tutorials/Remote-Attestation.html#remote-verifier-verifier-cpp

Note: the "Build and Test / *" failures seem to be unrelated to this PR.